### PR TITLE
Add a shell script for maintaining disposable_email_blocklist.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,7 @@ Feel free to create PR with additions or request removal of some domain (with re
 
 Specifically, if adding more than one new domain, please cite in your PR where one can generate a disposable email address which uses that domain, so the maintainers can verify it.
 
-Use:
-
-Add new disposable domains directly into [disposable_email_blocklist.conf](disposable_email_blocklist.conf) in the same format (only second level domains on new line without @), then run [maintain.sh](maintain.sh). The shell script will help you convert uppercase to lowercase, sort, remove duplicates and remove allowlisted domains.
+Please add new disposable domains directly into [disposable_email_blocklist.conf](disposable_email_blocklist.conf) in the same format (only second level domains on new line without @), then run [maintain.sh](maintain.sh). The shell script will help you convert uppercase to lowercase, sort, remove duplicates and remove allowlisted domains.
 
 Changelog
 ============

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ Specifically, if adding more than one new domain, please cite in your PR where o
 
 Use:
 
+if your system's localization settings are non-English (such as Chinese), please execute
+
+`$ LC_ALL=C; export LC_ALL`
+
+to temporary change the localization settings so that the `sort` command can produce the right order, then
+
 `$ cat disposable_email_blocklist.conf your_file | tr '[:upper:]' '[:lower:]' | sort -f | uniq -i  > new_file.conf`
 
 `$ comm -23 new_file.conf allowlist.conf > disposable_email_blocklist.conf`

--- a/README.md
+++ b/README.md
@@ -115,17 +115,7 @@ Specifically, if adding more than one new domain, please cite in your PR where o
 
 Use:
 
-if your system's localization settings are non-English (such as Chinese), please execute
-
-`$ LC_ALL=C; export LC_ALL`
-
-to temporary change the localization settings so that the `sort` command can produce the right order, then
-
-`$ cat disposable_email_blocklist.conf your_file | tr '[:upper:]' '[:lower:]' | sort -f | uniq -i  > new_file.conf`
-
-`$ comm -23 new_file.conf allowlist.conf > disposable_email_blocklist.conf`
-
-to add contents of another file in the same format (only second level domains on new line without @). It also converts uppercase to lowercase, sorts, removes duplicates and removes allowlisted domains.
+Add new disposable domains directly into [disposable_email_blocklist.conf](disposable_email_blocklist.conf) in the same format (only second level domains on new line without @), then run [maintain.sh](maintain.sh). The shell script will help you convert uppercase to lowercase, sort, remove duplicates and remove allowlisted domains.
 
 Changelog
 ============

--- a/maintain.sh
+++ b/maintain.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Unify locale settings temporarily to make sort produce the same order
+LC_ALL=C
+export LC_ALL
+
+# Converts uppercase to lowercase, sorts, removes duplicates and removes allowlisted domains
+cat disposable_email_blocklist.conf | tr '[:upper:]' '[:lower:]' | sort -f | uniq -i  > temp.conf
+comm -23 temp.conf allowlist.conf > disposable_email_blocklist.conf
+
+rm temp.conf
+echo "Done!"


### PR DESCRIPTION
My system's localization settings are Chinese, I won't produce the same order as the repo list using `cat disposable_email_blocklist.conf your_file | tr '[:upper:]' '[:lower:]' | sort -f | uniq -i > new_file.conf` unless executing `LC_ALL=C; export LC_ALL` beforehand.

![image](https://user-images.githubusercontent.com/43995067/109096256-2ebe8f80-7758-11eb-92b2-0b49edf09177.png)

Signed-off-by: Hollow Man <hollowman@hollowman.ml>