### PR TITLE
Add firemailbox.club, inboxkitten.com, tmpbox.net & more.. disposable domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,10 @@ function isDisposableEmail($email, $blocklist_path = null) {
     return in_array($domain, $disposable_domains);
 }
 ```
-**Ruby on Rails** 
+**Ruby on Rails** contributed by [@MitsunChieh](https://github.com/MitsunChieh)
 
-Use the `disposable_mail` gem: https://github.com/oesgalha/disposable_mail
+In the resource model, usually it is `user.rb`:
 
-Or in resource model, usually it is `user.rb` (contributed by [@MitsunChieh](https://github.com/MitsunChieh))
 ```Ruby
 before_validation :reject_email_blocklist
 
@@ -62,6 +61,9 @@ def reject_email_blocklist
   end
 end
 ```
+
+Alternatively you can use the `disposable_mail` gem: https://github.com/oesgalha/disposable_mail.
+
 **NodeJs** contributed by [@martin-fogelman](https://github.com/martin-fogelman)
 
 ```Node

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ function isDisposableEmail($email, $blocklist_path = null) {
     return in_array($domain, $disposable_domains);
 }
 ```
-**Ruby on Rails** contributed by [@MitsunChieh](https://github.com/MitsunChieh)
+**Ruby on Rails** 
 
-In resource model, usually it is `user.rb`
+Use the `disposable_mail` gem: https://github.com/oesgalha/disposable_mail
+
+Or in resource model, usually it is `user.rb` (contributed by [@MitsunChieh](https://github.com/MitsunChieh))
 ```Ruby
 before_validation :reject_email_blocklist
 

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1031,6 +1031,7 @@ filzmail.com
 findemail.info
 findu.pl
 fir.hk
+firemailbox.club
 fitnesrezink.ru
 fivemail.de
 fixmail.tk

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1403,6 +1403,7 @@ inboxclean.org
 inboxdesign.me
 inboxed.im
 inboxed.pw
+inboxkitten.com
 inboxproxy.com
 inboxstore.me
 inclusiveprogress.com
@@ -1911,6 +1912,7 @@ ml8.ca
 mm.my
 mm5.se
 mnode.me
+moakt.cc
 moakt.co
 moakt.com
 moakt.ws
@@ -2791,6 +2793,7 @@ tmail.com
 tmail.ws
 tmailinator.com
 tmails.net
+tmpbox.net
 tmpemails.com
 tmpeml.info
 tmpjr.me

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3089,6 +3089,7 @@ widaryanto.info
 widget.gg
 wierie.tk
 wifimaple.com
+wifioak.com
 wikidocuslava.ru
 wilemail.com
 willhackforfood.biz

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3088,6 +3088,7 @@ wickmail.net
 widaryanto.info
 widget.gg
 wierie.tk
+wifimaple.com
 wikidocuslava.ru
 wilemail.com
 willhackforfood.biz

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -576,7 +576,6 @@ cndps.com
 cnew.ir
 cnmsg.net
 cnsds.de
-cnxingye.com
 co.cc
 cobarekyo1.ml
 cocoro.uk

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -576,6 +576,7 @@ cndps.com
 cnew.ir
 cnmsg.net
 cnsds.de
+cnxingye.com
 co.cc
 cobarekyo1.ml
 cocoro.uk
@@ -1710,6 +1711,7 @@ mail2rss.org
 mail333.com
 mail4trash.com
 mail666.ru
+mail7.io
 mail707.com
 mail72.com
 mailapp.top


### PR DESCRIPTION
Hello :wave:

I got a lot of disposable emails from this `firemailbox.club` domain on my project and noticed it's not yet in the list.
Here is where we can generate disposable email on this domain: https://www.mohmal.com/fr/inbox
And here is another third-party classifying this domain as disposable: https://www.ipqualityscore.com/domain-reputation/firemailbox.club

Edit: I also discovered and added:
- `inboxkitten.com` (link to generate emails: https://inboxkitten.com/, same third-party classifying as disposable: https://www.ipqualityscore.com/domain-reputation/inboxkitten.com)
- `tmpbox.net` (link to generate emails: https://www.moakt.com/, third-party: https://www.ipqualityscore.com/domain-reputation/tmpbox.net)
- `moakt.cc` (another domain from https://www.moakt.com/, I checked the others and they are already in the list)
- `wifimaple.com` (link to generate emails: https://www.fakemail.net/, third-party: https://www.ipqualityscore.com/domain-reputation/wifimaple.com)
- `wifioak.com` (link to generate emails: https://www.minuteinbox.com/, third-party: https://www.ipqualityscore.com/domain-reputation/wifioak.com)
- `mail7.io` (link to generate emails: https://mail7.io/)
- `cnxingye.com` (couldn't find the website to generate but found many third parties considering them as disposable: https://www.ipqualityscore.com/domain-reputation/cnxingye.com, https://disposable.help/domain/cnxingye.com)

Thanks for this great list by the way!

---

Also I took the liberty to add the link to one Ruby on Rails gem which integrates this list in the readme: https://github.com/oesgalha/disposable_mail
Let me know if you prefer me to remove that.