### PR TITLE
Add quicksend.ch

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2309,6 +2309,7 @@ quick-mail.cc
 quickemail.info
 quickinbox.com
 quickmail.nl
+quicksend.ch
 ququb.com
 qvy.me
 qwickmail.com


### PR DESCRIPTION
We can obtain a disposable email address for this domain by following the steps below.

1. Access to https://m.kuku.lu/
2. Click "Create an address with expiration" ("期限つきの使い捨てアドレス" in Japanese)

![image](https://user-images.githubusercontent.com/1357608/138387311-e3dfc0f0-b843-4f27-9bac-3a09b76987f9.png)

![image](https://user-images.githubusercontent.com/1357608/138387218-db345c3b-7baf-4c6a-80f8-5cd08c87927f.png)
