### PR TITLE
Add domains available on https://mail.td/

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1172,6 +1172,7 @@ getnada.com
 getnowtoday.cf
 getonemail.com
 getonemail.net
+getover.de
 getsimpleemail.com
 gett.icu
 ghosttexter.de
@@ -2697,6 +2698,7 @@ tapi.re
 tarzanmail.cf
 tastrg.com
 tb-on-line.net
+tdtda.com
 tech69.com
 techemail.com
 techgroup.me
@@ -2957,6 +2959,7 @@ ushijima1129.tk
 utiket.us
 uu.gl
 uu2.ovh
+uuf.me
 uwork4.us
 uyhip.com
 vaasfc4.tk


### PR DESCRIPTION
Add the following domains to the block list

- getover[.]de
- tdtda[.]com
- uuf[.]me

Email addresses for these domains can be obtained from https://mail.td
