### PR TITLE
Move shitware.nl to allowlist

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -142,6 +142,7 @@ sent.as
 sent.at
 sent.com
 shitposting.agency
+shitware.nl
 sibmail.com
 sneakemail.com
 snkmail.com

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2480,7 +2480,6 @@ shitaway.tk
 shitmail.de
 shitmail.me
 shitmail.org
-shitware.nl
 shmeriously.com
 shortmail.net
 shotmail.ru


### PR DESCRIPTION
Fixes #300. This domain doesn't meet our standards for a disposable email domain.