### PR TITLE
Add mozmail.com to allowlist.conf (Firefox Relay)

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -116,6 +116,7 @@ mailworks.org
 memeware.net
 ml1.net
 mm.st
+mozmail.com
 myfastmail.com
 mymacmail.com
 naver.com


### PR DESCRIPTION
Per the discussion/decision from This domain (discussed in https://github.com/disposable-email-domains/disposable-email-domains/pull/298), moving this domain to the allowlist.

See more about the service at [relay.firefox.com](https://relay.firefox.com)
