### PR TITLE
Added additional disposable domain

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2973,6 +2973,7 @@ tmail.com
 tmail.ws
 tmailinator.com
 tmails.net
+tmmbt.net
 tmpbox.net
 tmpemails.com
 tmpeml.com


### PR DESCRIPTION
Added tmmbt.net as domain. I just had a registration from this domain and checked it as a disposable 10 minute email provider.

If you are adding domains please state where one can generate a disposable email address which uses the added domains, so the maintainers can verify it. Without this information your PR will be closed.
