### PR TITLE
add boxmail.lol (used by mohmal.com)

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -485,6 +485,7 @@ boun.cr
 bouncr.com
 boxformail.in
 boximail.com
+boxmail.lol
 boxomail.live
 boxtemp.com.br
 bptfp.net


### PR DESCRIPTION
New domain used by https://www.mohmal.com/ar/inbox
