### PR TITLE
Missing some domains.

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3460,3 +3460,6 @@ zymuying.com
 zzi.us
 zzrgg.com
 zzz.com
+jollyfree.com
+doojazz.com
+fr.cr

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3460,6 +3460,5 @@ zymuying.com
 zzi.us
 zzrgg.com
 zzz.com
-jollyfree.com
 doojazz.com
 fr.cr


### PR DESCRIPTION
note: .fr.cr was being used here: https://yopmail.com/en/alternate-domains

other link: https://www.disposablemail.com/