### PR TITLE
Add fextemp.com to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1083,6 +1083,7 @@ fettometern.com
 fexbox.org
 fexbox.ru
 fexpost.com
+fextemp.com
 ficken.de
 fictionsite.com
 fightallspam.com


### PR DESCRIPTION
Addresses `@fextemp.com` can be registered at https://tempmail.plus