### PR TITLE
More trash mail domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -22,6 +22,7 @@
 10dk.email
 10mail.com
 10mail.org
+10mail.tk
 10minut.com.pl
 10minut.xyz
 10minutemail.be
@@ -343,6 +344,7 @@ antireg.ru
 antispam.de
 antispam24.de
 antispammail.de
+any.pink
 anyalias.com
 aoeuhtns.com
 apfelkorps.de
@@ -781,6 +783,7 @@ discard.tk
 discardmail.com
 discardmail.de
 discos4.com
+dishcatfish.com
 disign-concept.eu
 disign-revelation.com
 dispo.in
@@ -832,6 +835,7 @@ domforfb7.tk
 domforfb8.tk
 domforfb9.tk
 domozmail.com
+donebyngle.com
 donemail.ru
 dongqing365.com
 dontreg.com
@@ -858,6 +862,7 @@ dropjar.com
 droplar.com
 dropmail.me
 dropsin.net
+drowblock.com
 dsgvo.ru
 dsiay.com
 dspwebservices.com
@@ -1039,6 +1044,7 @@ ez.lv
 ezehe.com
 ezfill.com
 ezstest.com
+ezztt.com
 f4k.es
 f5.si
 facebook-email.cf
@@ -1130,6 +1136,7 @@ fluidsoft.us
 flurred.com
 fly-ts.de
 flyinggeek.net
+flymail.tk
 flyspam.com
 foobarbot.net
 footard.com
@@ -1283,6 +1290,7 @@ gishpuppy.com
 giveh2o.info
 givememail.club
 givmail.com
+gixenmixen.com
 glitch.sx
 globaltouron.com
 glubex.com
@@ -1382,6 +1390,7 @@ hairs24.ru
 haltospam.com
 hamham.uk
 hangxomcuatoilatotoro.ml
+happy2023year.com
 happydomik.ru
 harakirimail.com
 haribu.com
@@ -1469,6 +1478,7 @@ icemail.club
 ichigo.me
 icx.in
 icx.ro
+icznn.com
 idx4.com
 idxue.com
 ieatspam.eu
@@ -1491,6 +1501,7 @@ imailt.com
 imgof.com
 imgv.de
 immo-gerance.info
+imperialcnk.com
 imstations.com
 imul.info
 in-ulm.de
@@ -1541,6 +1552,7 @@ instantblingmail.info
 instantemailaddress.com
 instantmail.fr
 internet-v-stavropole.ru
+internetkeno.com
 internetoftags.com
 interstats.org
 intersteller.com
@@ -1670,6 +1682,7 @@ klassmaster.net
 klick-tipp.us
 klipschx12.com
 kloap.com
+klovenode.com
 kludgemush.com
 klzlk.com
 kmail.li
@@ -2020,6 +2033,7 @@ meltmail.com
 memsg.site
 mentonit.net
 mepost.pw
+merepost.com
 merry.pink
 messagebeamer.de
 messwiththebestdielikethe.rest
@@ -2046,6 +2060,7 @@ migmail.pl
 migumail.com
 mihep.com
 mijnhva.nl
+minimail.gq
 ministry-of-silly-walks.de
 minsmail.com
 mintemail.com
@@ -2137,11 +2152,13 @@ myecho.es
 myemailboxy.com
 mygeoweb.info
 myindohome.services
+myinfoinc.com
 myinterserver.ml
 mykickassideas.com
 mymail-in.net
 mymail90.com
 mymailoasis.com
+mymaily.lol
 mynetstore.de
 myopang.com
 mypacks.net
@@ -2341,6 +2358,7 @@ owleyes.ch
 owlpic.com
 ownsyou.de
 oxopoha.com
+ozatvn.com
 ozyl.de
 p-banlis.ru
 p33.org
@@ -2639,6 +2657,7 @@ services391.com
 sexforswingers.com
 sexical.com
 sexyalwasmi.top
+sfolkar.com
 shadap.org
 shalar.net
 sharedmailbox.org
@@ -2690,6 +2709,7 @@ skeefmail.com
 skrx.tk
 sky-inbox.com
 sky-ts.de
+skygazerhub.com
 skyrt.de
 slapsfromlastnight.com
 slaskpost.se
@@ -2826,6 +2846,7 @@ spritzzone.de
 spruzme.com
 spybox.de
 spymail.com
+spymail.one
 squizzy.de
 squizzy.net
 sroff.com
@@ -2867,6 +2888,7 @@ sueshaw.com
 suexamplesb.com
 suioe.com
 super-auswahl.de
+superblohey.com
 supergreatmail.com
 supermailer.jp
 superplatyna.com
@@ -3027,6 +3049,8 @@ tkitc.de
 tlpn.org
 tmail.com
 tmail.ws
+tmail3.com
+tmail9.com
 tmailinator.com
 tmails.net
 tmmbt.net
@@ -3289,6 +3313,7 @@ watch-harry-potter.com
 watchever.biz
 watchfull.net
 watchironman3onlinefreefullmovie.com
+waterisgone.com
 wazabi.club
 wbdev.tech
 wbml.net
@@ -3498,6 +3523,7 @@ zhewei88.com
 zhorachu.com
 zik.dj
 zipcad.com
+zipcatfish.com
 zipo1.gq
 zippymail.info
 zipsendtest.com


### PR DESCRIPTION
Added 26 new domains from this sites:


- https://dropmail.me/
- https://tempmail.plus/
- https://mail.tm/en/
- https://www.disposablemail.com/
- https://www.tmail.gg/
- https://temp-mail.org/
- https://www.mohmal.com/
- https://tempmailo.com/
- https://tempail.com/
- https://internxt.com/
- https://temp-mail.io/
- https://www.emailondeck.com/
- https://www.guerrillamail.com/
