### PR TITLE
Add some domains from InstAddr

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -558,6 +558,7 @@ cartelera.org
 caseedu.tk
 cashflow35.com
 casualdx.com
+catgroup.uk
 cavi.mx
 cbair.com
 cbes.net
@@ -1002,6 +1003,7 @@ eposta.work
 eqiluxspam.ga
 ereplyzy.com
 ericjohnson.ml
+eripo.net
 ero-tube.org
 esadverse.com
 esbano-ru.ru
@@ -1297,6 +1299,7 @@ gmxmail.win
 gnctr-calgary.com
 go2usa.info
 go2vpn.net
+goatmail.uk
 goemailgo.com
 golemico.com
 gomail.in
@@ -2270,6 +2273,7 @@ nwldx.com
 nwytg.com
 nwytg.net
 ny7.me
+nyasan.com
 nypato.com
 nyrmusic.com
 o2stk.org
@@ -2646,6 +2650,7 @@ shadap.org
 shalar.net
 sharedmailbox.org
 sharklasers.com
+shchiba.uk
 sheryli.com
 shhmail.com
 shhuut.org

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1542,6 +1542,7 @@ instant-mail.de
 instantblingmail.info
 instantemailaddress.com
 instantmail.fr
+instmail.uk
 internet-v-stavropole.ru
 internetoftags.com
 interstats.org


### PR DESCRIPTION
The disposable e-mail domains from InstAddr ( https://m.kuku.lu/ )
"instmail.uk" domain is used for the disposable e-mail address with expiration.
"eripo.net", "nyasan.com", and "shchiba.uk" domains are available only in Japan.