### PR TITLE
Add ridteam.com to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2560,6 +2560,7 @@ rfc822.org
 rhyta.com
 richfinances.pw
 riddermark.de
+ridteam.com
 rifkian.ga
 rippb.com
 risingsuntouch.com


### PR DESCRIPTION
This domain is used by https://temp-mail.org/
