### PR TITLE
Add sparkroi.com to disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2831,6 +2831,7 @@ spamwc.cf
 spamwc.ga
 spamwc.gq
 spamwc.ml
+sparkroi.com
 speedgaus.net
 sperma.cf
 spikio.com


### PR DESCRIPTION
ZeroBounce identifies this as disposable email domain.  We had some issues with this domain. And then checked in ZeroBounce and found that this is a disposable email domain.

