### PR TITLE
Added other sneakemail.com domains to allowlist

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -94,6 +94,7 @@ internetmailing.net
 jetemail.net
 justemail.net
 letterboxes.org
+liamekaens.com
 mail-central.com
 mail-page.com
 mail2world.com
@@ -148,6 +149,7 @@ shitware.nl
 sibmail.com
 sneakemail.com
 snkmail.com
+snkml.com
 spamcannon.com
 spamcannon.net
 spamgourmet.com


### PR DESCRIPTION
Added other domains all connected to sneakemail.com which is already on the allow list.

See:
https://github.com/FGRibreau/mailchecker/issues/139
https://github.com/FGRibreau/mailchecker/pull/150
https://github.com/FGRibreau/mailchecker/pull/319
https://github.com/nfacha/temporary-email-list/pull/2
https://github.com/FGRibreau/mailchecker/pull/414

Alredy present:
sneakemail.com
snkmail.com

Added:
liamekaens.com
snkml.com