### PR TITLE
Add fakermail.com domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -583,6 +583,7 @@ chatich.com
 cheaphub.net
 cheatmail.de
 chenbot.email
+chewydonut.com
 chibakenma.ml
 chickenkiller.com
 chielo.com
@@ -1466,6 +1467,7 @@ hushmail.cf
 huskion.net
 hvastudiesucces.nl
 hwsye.net
+hypenated-domain.com
 i2pmail.org
 i6.cloudns.cc
 iaoss.com
@@ -1580,6 +1582,7 @@ it7.ovh
 italy-mail.com
 itcompu.com
 itfast.net
+itsjiff.com
 itunesgiftcodegenerator.com
 iubridge.com
 iuemail.men
@@ -1767,6 +1770,7 @@ lifetotech.com
 ligsb.com
 lillemap.net
 lilo.me
+lilspam.com
 lindenbaumjapan.com
 link2mail.net
 linkedintuts2016.pw
@@ -1859,6 +1863,7 @@ mail72.com
 mailapp.top
 mailback.com
 mailbidon.com
+mailbiscuit.com
 mailbiz.biz
 mailblocks.com
 mailbox.in.ua
@@ -2404,6 +2409,7 @@ pisls.com
 pitaniezdorovie.ru
 pivo-bar.ru
 pixiil.com
+pizzajunk.com
 pjjkp.com
 placebomail10.com
 pleasenoham.org
@@ -2534,6 +2540,7 @@ rdklcrv.xyz
 re-gister.com
 reality-concept.club
 reallymymail.com
+realquickemail.com
 realtyalerts.ca
 rebates.stream
 receiveee.com
@@ -2656,6 +2663,7 @@ sexyalwasmi.top
 shadap.org
 shalar.net
 sharedmailbox.org
+sharkfaces.com
 sharklasers.com
 shchiba.uk
 sheryli.com
@@ -2686,6 +2694,7 @@ siftportal.ru
 sify.com
 sika3.com
 sikux.com
+silenceofthespam.com
 siliwangi.ga
 silvercoin.life
 sim-simka.ru
@@ -2730,12 +2739,14 @@ smellrear.com
 smellypotato.tk
 smtp99.com
 smwg.info
+snakebutt.com
 snakemail.com
 snapwet.com
 sneakmail.de
 snece.com
 social-mailer.tk
 socialfurry.org
+sociallymediocre.com
 sofia.re
 sofimail.com
 sofort-mail.de
@@ -2789,6 +2800,7 @@ spamcowboy.org
 spamday.com
 spamdecoy.net
 spamex.com
+spamfellas.com
 spamfighter.cf
 spamfighter.ga
 spamfighter.gq
@@ -2817,6 +2829,7 @@ spammy.host
 spamobox.com
 spamoff.de
 spamsalad.in
+spamsandwich.com
 spamslicer.com
 spamsphere.com
 spamspot.com
@@ -3005,6 +3018,7 @@ themostemail.com
 thereddoors.online
 theroyalweb.club
 thescrappermovie.com
+thespamfather.com
 theteastory.info
 thex.ro
 thichanthit.com
@@ -3352,6 +3366,7 @@ wetrainbayarea.org
 wfgdfhj.tk
 wg0.com
 wh4f.org
+whaaaaaaaaaat.com
 whatiaas.com
 whatifanalytics.com
 whatpaas.com


### PR DESCRIPTION
Adds the following email domains which can all be registered at https://fakermail.com/

`@chewydonut.com`
`@hypenated-domain.com`
`@itsjiff.com`
`@lilspam.com`
`@mailbiscuit.com`
`@pizzajunk.com`
`@realquickemail.com`
`@sharkfaces.com`
`@silenceofthespam.com`
`@snakebutt.com`
`@sociallymediocre.com`
`@spamfellas.com`
`@spamsandwich.com`
`@thespamfather.com`
`@whaaaaaaaaaat.com`

The generator on that page picks a random domain each time, but the full list is retrieved from https://fakermail.com/api/domains on pageload