### PR TITLE
Add 4 new domains from InstAddr

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -255,6 +255,7 @@ akapost.com
 akerd.com
 akgq701.com
 akmail.in
+akugu.com
 al-qaeda.us
 albionwe.us
 alchemywe.us
@@ -410,6 +411,7 @@ badgerland.eu
 badoop.com
 badpotato.tk
 balaket.com
+bangban.uk
 banit.club
 banit.me
 bank-opros1.ru
@@ -2354,6 +2356,7 @@ onewaymail.com
 onlatedotcom.info
 online.ms
 onlineidea.info
+onlyapp.net
 onqin.com
 ontyne.biz
 oohioo.com
@@ -2518,6 +2521,7 @@ purelogistics.org
 put2.net
 puttanamaiala.tk
 putthisinyourspamdatabase.com
+pwpwa.com
 pwrby.com
 qasti.com
 qbfree.us


### PR DESCRIPTION
The disposable e-mail domains from [InstAddr](https://m.kuku.lu/)
"onlyapp.net" domain is available only in Japan.
"akugu.com" and "pwpwa.com" domains are originally available for premium users, but it seems available also for free users now.
![Screenshot](https://iwtf1.caching.ovh/to/that/2023/08/28/image2c6583eaddd2b07e.png)