### PR TITLE
Delete "0clickemail.com" from list as not working now

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -5,7 +5,6 @@
 0815.su
 0845.ru
 0box.eu
-0clickemail.com
 0n0ff.net
 0nelce.com
 0v.ro


### PR DESCRIPTION
This domain is not used for disposable e-mail service.
