### PR TITLE
Add domains - generated from temp-mail.org

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1,3 +1,6 @@
+locawin.com
+mugadget.com
+ksyhtc.com
 0-mail.com
 027168.com
 0815.ru

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1,6 +1,3 @@
-locawin.com
-mugadget.com
-ksyhtc.com
 0-mail.com
 027168.com
 0815.ru
@@ -1743,6 +1740,7 @@ krsw.tk
 kruay.com
 krypton.tk
 ksmtrck.tk
+ksyhtc.com
 kuhrap.com
 kulmeo.com
 kulturbetrieb.info
@@ -1822,6 +1820,7 @@ loapq.com
 locanto1.club
 locantofuck.top
 locantowsite.club
+locawin.com
 locomodev.net
 login-email.cf
 login-email.ga
@@ -2174,6 +2173,7 @@ muell.monster
 muell.xyz
 muellemail.com
 muellmail.com
+mugadget.com
 munoubengoshi.gq
 musiccode.me
 mutant.me


### PR DESCRIPTION
Found disposible `emails` at https://temp-mail.org/en/
### Description:
Added 3 domains `locawin.com`, `ksyhtc.com` and `mugadget.com`. Following are the evidences to regenerate emails.

![image](https://github.com/disposable-email-domains/disposable-email-domains/assets/57555839/b182819b-0a62-4e3e-8c7e-8a994a4d10ea)
![image](https://github.com/disposable-email-domains/disposable-email-domains/assets/57555839/180ef8f8-3055-4ad9-83e1-ef1a58c70c51)
