### PR TITLE
Added serveral domains to block list

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -553,6 +553,10 @@ byom.de
 c51vsgq.com
 cachedot.net
 californiafitnessdeals.com
+cazlg.com
+cazlp.com
+cazlq.com
+cazlv.com
 cam4you.cc
 camping-grill.info
 candymail.de
@@ -611,6 +615,7 @@ civikli.com
 civx.org
 ckaazaza.tk
 ckiso.com
+ckptr.com
 cl-cl.org
 cl0ne.net
 claimab.com
@@ -690,6 +695,7 @@ cust.in
 cutout.club
 cutradition.com
 cuvox.de
+cwmxc.com
 cyber-innovation.club
 cyber-phone.eu
 cylab.org


### PR DESCRIPTION
these domains are provided here: https://10minutemail.com/

if you run the following bash script, it will generate a selection for you:

```
for run in {1..10}; do
  curl 'https://10minutemail.com/session/address' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0';echo '\n'
done
```

although if you do it too much, it does start returning:

```
{"timestamp":"2023-10-24T07:20:51.225+00:00","status":403,"error":"Forbidden","path":"/session/address"}
```

so i assume it blacklists IPs, but i'm not sure.