### PR TITLE
Update +6 domains in disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -641,6 +641,8 @@ cocoro.uk
 cocovpn.com
 codeandscotch.com
 codivide.com
+codvip.net
+codjobs.com
 coffeetimer24.com
 coieo.com
 coin-host.net
@@ -1641,6 +1643,7 @@ jobbikszimpatizans.hu
 jobbrett.com
 jobposts.net
 jobs-to-be-done.net
+jocdk.com
 joelpet.com
 joetestalot.com
 jopho.com
@@ -2176,6 +2179,7 @@ musiccode.me
 mutant.me
 mvrht.com
 mvrht.net
+mvpve.com
 mwarner.org
 mxclip.com
 mxfuel.com
@@ -2413,6 +2417,7 @@ pa9e.com
 pachilly.com
 packiu.com
 pagamenti.tk
+page.edu.pl
 paharpurmim.ga
 pakadebu.ga
 pamaweb.com
@@ -2685,6 +2690,7 @@ schmeissweg.tk
 schrott-email.de
 scrsot.com
 sd3.in
+sdkjob.com
 sdvft.com
 sdvgeft.com
 sdvrecft.com


### PR DESCRIPTION
I am writing to request the following domains be added to the list of disposable email domains:

`codvip.net`
`codjobs.com`
`sdkjob.com`
`page.edu.pl`
`jocdk.com`
`mvpve.com`
(6 domains)

These domains are available for use through the following service: https://temp-mailbox.com/change

Please, consider adding them to the blocklist. Thanks!
