### PR TITLE
Update disposable_email_blocklist.conf, add more email

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -250,6 +250,7 @@ ahem.email
 ahk.jp
 ahmedkhlef.com
 air2token.com
+ai1.lol
 airmailbox.website
 airsi.de
 ajaxapp.net
@@ -552,6 +553,7 @@ byespm.com
 byom.de
 c51vsgq.com
 cachedot.net
+cazlg.com
 californiafitnessdeals.com
 cam4you.cc
 camping-grill.info
@@ -605,6 +607,7 @@ choicemail1.com
 chong-mail.com
 chong-mail.net
 chong-mail.org
+chronicle.digital
 chumpstakingdumps.com
 cigar-auctions.com
 civikli.com
@@ -942,6 +945,7 @@ emailage.gq
 emailage.ml
 emailage.tk
 emailate.com
+emailbox.click
 emailbin.net
 emailcu.icu
 emaildienst.de
@@ -1586,6 +1590,7 @@ iozak.com
 ip4.pp.ua
 ip6.li
 ip6.pp.ua
+ipahive.org
 ipoo.org
 ippandansei.tk
 ipsur.org
@@ -1619,6 +1624,7 @@ jaga.email
 jajxz.com
 janproz.com
 jaqis.com
+javdeno.site
 jdmadventures.com
 jdz.ro
 je-recycle.info
@@ -1657,6 +1663,7 @@ junkmail.ga
 junkmail.gq
 just-email.com
 justemail.ml
+juvintagew.com
 juyouxi.com
 jwork.ru
 kademen.com
@@ -1791,6 +1798,7 @@ lellno.gq
 lenovog4.com
 lerbhe.com
 letmeinonthis.com
+lettrs.email
 letthemeatspam.com
 lez.se
 lgxscreen.com
@@ -2182,6 +2190,7 @@ mxfuel.com
 my-pomsies.ru
 my-teddyy.ru
 my10minutemail.com
+my2ducks.com
 mybitti.de
 mycleaninbox.net
 mycorneroftheinter.net
@@ -2413,6 +2422,7 @@ pa9e.com
 pachilly.com
 packiu.com
 pagamenti.tk
+page.edu.pl
 paharpurmim.ga
 pakadebu.ga
 pamaweb.com
@@ -2598,6 +2608,7 @@ recode.me
 reconmail.com
 recyclemail.dk
 redfeathercrow.com
+refined.blog
 reftoken.net
 regbypass.com
 regspaces.tk
@@ -3571,6 +3582,7 @@ z86.ru
 zain.site
 zainmax.net
 zaktouni.fr
+zamaneta.com
 zarabotokdoma11.ru
 zasod.com
 zaym-zaym.ru


### PR DESCRIPTION
If you are adding domains please state where one can generate a disposable email address which uses the added domains, so the maintainers can verify it. Without this information your PR will be closed.

email domain: zamaneta.com 
site: https://temp-mail.org/en/ 

email domain: my2ducks.com
site: https://www.minuteinbox.com/

email domain: refined.blog, lettrs.email
site: https://10minute-email.com/

email doamin: ipahive.org
site: https://10minutesemail.net/

email domain: page.edu.pl
site: https://10minutemail.one/

email domain: iubridge.com
site: https://www.linshi-email.com/en

email domain: javdeno.site
site: https://etempmail.net/10minutemail

email domain: codjobs.com
site: https://temp-mailbox.com/10minutemail/

email domain: zamaneta.com
site: https://10minemail.com/en/

email domain: ckptr.com
site: https://10minutemail.com/