### PR TITLE
Update disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -737,6 +737,7 @@ deadspam.com
 deagot.com
 dealja.com
 dealrek.com
+deecie.com
 deekayen.us
 defomail.com
 degradedfun.net
@@ -3451,6 +3452,7 @@ willselfdestruct.com
 wimsg.com
 winemaven.info
 wins.com.br
+wireconnected.com
 wlist.ro
 wmail.cf
 wmail.club


### PR DESCRIPTION
I found two more temp emails that were not in this list, just added them!

If you are adding domains please state where one can generate a disposable email address which uses the added domains, so the maintainers can verify it. Without this information your PR will be closed.
