### PR TITLE
Remove xwaretech domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3502,9 +3502,6 @@ xperiae5.com
 xrap.de
 xrho.com
 xvx.us
-xwaretech.com
-xwaretech.info
-xwaretech.net
 xww.ro
 xxhamsterxx.ga
 xxi2.com


### PR DESCRIPTION
Years ago pointed to mailinator, now they don't. They are my personal domains and when I put them into use I began using them with regular email provider at Fastmail. Please process the removal, thanks.