### PR TITLE
added emails from https://temp-mail.org

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2979,6 +2979,7 @@ taglead.com
 tagmymedia.com
 tagyourself.com
 talkinator.com
+tanlanav.com
 tanukis.org
 tapchicuoihoi.com
 taphear.com
@@ -3003,6 +3004,7 @@ teleg.eu
 teleworm.com
 teleworm.us
 tellos.xyz
+telvetto.com
 teml.net
 temp-link.net
 temp-mail.com

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2599,6 +2599,7 @@ reconmail.com
 recyclemail.dk
 redfeathercrow.com
 reftoken.net
+regapts.com
 regbypass.com
 regspaces.tk
 reimondo.com
@@ -2629,6 +2630,7 @@ rmqkr.net
 rnailinator.com
 ro.lt
 robertspcrepair.com
+roborena.com
 robot-mail.com
 rollindo.agency
 ronnierage.net
@@ -2979,8 +2981,10 @@ taglead.com
 tagmymedia.com
 tagyourself.com
 talkinator.com
+talmetry.com
 tanlanav.com
 tanukis.org
+taobudao.com
 tapchicuoihoi.com
 taphear.com
 tapi.re


### PR DESCRIPTION
You can go to https://temp-mail.org/ to get new temporary emails.

Please go to the website in incognito mode. If you close the incognito mode and open the url in incognito again it has a chance of giving you temporary email from a different domain.