### PR TITLE
add allowlist(kakao.com) and blocklist(from 3 sources)

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -93,6 +93,7 @@ internetemails.net
 internetmailing.net
 jetemail.net
 justemail.net
+kakao.com
 letterboxes.org
 liamekaens.com
 mail-central.com

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -549,6 +549,7 @@ buyusedlibrarybooks.org
 buzzcluby.com
 byebyemail.com
 byespm.com
+c01.kr
 byom.de
 c51vsgq.com
 cachedot.net
@@ -655,6 +656,7 @@ contbay.com
 cooh-2.site
 coolandwacky.us
 coolimpool.org
+copyhome.win
 coreclip.com
 cosmorph.com
 courrieltemporaire.com
@@ -1328,6 +1330,7 @@ goonby.com
 goplaygame.ru
 gorillaswithdirtyarmpits.com
 goround.info
+gosarlar.com
 gosuslugi-spravka.ru
 gothere.biz
 gotmail.com
@@ -1590,6 +1593,7 @@ ipoo.org
 ippandansei.tk
 ipsur.org
 irabops.com
+iralborz.bid
 irc.so
 irish2me.com
 irishspringrealty.com
@@ -1743,6 +1747,7 @@ ksmtrck.tk
 kuhrap.com
 kulmeo.com
 kulturbetrieb.info
+kumli.racing
 kurzepost.de
 kutakbisajauhjauh.gq
 kvhrr.com
@@ -2654,6 +2659,7 @@ runi.ca
 rupayamail.com
 ruru.be
 rustydoor.com
+ruu.kr
 rvb.ro
 ryteto.me
 s0ny.net

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -549,8 +549,8 @@ buyusedlibrarybooks.org
 buzzcluby.com
 byebyemail.com
 byespm.com
-c01.kr
 byom.de
+c01.kr
 c51vsgq.com
 cachedot.net
 californiafitnessdeals.com


### PR DESCRIPTION
Hello,

I am looking to contribute to your project by updating the list of disposable email domains to help mitigate the use of temporary emails. In this pull request, I have added new disposable email domains to `disposable_email_blocklist.conf` and included a safe domain in `allowlist.conf`.

### Added Disposable Email Domains
- **c01.kr**: Can be generated at [temp-mail.winsub.kr](https://temp-mail.winsub.kr), a Korean disposable email provider.
- **copyhome.win, iralborz.bid, kumli.racing, ruu.kr**: Can be generated at [ruu.kr](https://ruu.kr), another Korean disposable email provider.
- **gosarlar.com**: Can be generated at [temp-mail.org](https://temp-mail.org), a widely used disposable email service.

### Added to Allowlist
- **kakao.com**: This domain is provided by Kakao, the company behind KakaoTalk, for use by its members in South Korea. It is generally safe and not used as a disposable email domain.

I have included links where the disposable email addresses can be generated for each domain, allowing the maintainers to verify their validity. The addition of `kakao.com` to the allowlist reflects its status as a legitimate and widely used domain, not associated with disposable email services. I hope this contribution is beneficial to the project, and I am open to any feedback or additional information that may be required.

Thank you.