### PR TITLE
Update disposable_email_blocklist.conf - 48hr.email

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -626,8 +626,8 @@ clickdeal.co
 clipmail.eu
 clixser.com
 clonemoi.tk
-cloudflare.gay
 cloud-mail.top
+cloudflare.gay
 cloudns.cx
 clout.wiki
 clrmail.com

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -111,6 +111,7 @@
 4057.com
 418.dk
 42o.org
+48hr.email
 4gfdsgfdgfd.tk
 4k5.net
 4mail.cf
@@ -167,6 +168,7 @@
 9ox.net
 9q.ro
 a-bc.net
+a-germandu.de
 a45.in
 a7996.com
 aa5zy64.com
@@ -624,6 +626,7 @@ clickdeal.co
 clipmail.eu
 clixser.com
 clonemoi.tk
+cloudflare.gay
 cloud-mail.top
 cloudns.cx
 clout.wiki
@@ -1180,6 +1183,7 @@ frappina.tk
 free-email.cf
 free-email.ga
 free-temp.net
+free-tools.club
 freebabysittercam.com
 freeblackbootytube.com
 freecat.net
@@ -2642,6 +2646,7 @@ ro.lt
 robertspcrepair.com
 roborena.com
 robot-mail.com
+roguemaster.dev
 rollindo.agency
 ronnierage.net
 rootfest.net
@@ -2835,6 +2840,7 @@ soodomail.com
 soodonims.com
 soombo.com
 soon.it
+soyboy.observer
 spacebazzar.ru
 spam-be-gone.com
 spam.care
@@ -3477,6 +3483,7 @@ wokcy.com
 wolfmail.ml
 wolfsmail.tk
 wollan.info
+womp-wo.mp
 worldspace.link
 wpdork.com
 wpg.im


### PR DESCRIPTION
adds following domains from [48hr.email](https://48hr.email/):
```
48hr.email
a-germandu.de
cloudflare.gay
free-tools.club
roguemaster.dev
soyboy.observer
womp-wo.mp
```
