### PR TITLE
2 new Temp-mail domains added to the blocklist.

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1786,6 +1786,7 @@ lastmail.com
 lawlita.com
 lazyinbox.com
 lazyinbox.us
+laymro.com
 ldaho.biz
 ldop.com
 ldtp.com
@@ -3173,6 +3174,7 @@ totalvista.com
 totesmail.com
 totoan.info
 tourcc.com
+tospage.com
 tp-qa-mail.com
 tpwlb.com
 tqoai.com


### PR DESCRIPTION
I have generated these 2 disposable email at "https://temp-mail.org/en/"

![Screenshot 2024-02-19 at 1 10 41 PM](https://github.com/disposable-email-domains/disposable-email-domains/assets/836773/d1ad9577-7d10-4bd3-a6f2-d4053de4af63)
![Screenshot 2024-02-19 at 1 10 50 PM](https://github.com/disposable-email-domains/disposable-email-domains/assets/836773/64f09fcf-2c23-444f-b4a7-9cace67823c9)
