### PR TITLE
Add ubicloud.com to allowlist

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -165,6 +165,7 @@ the-fastest.net
 the-quickest.com
 theinternetemail.com
 tweakly.net
+ubicloud.com
 veryfast.biz
 veryspeedy.net
 waifu.club


### PR DESCRIPTION
We've had various problems over the last year (when we came into ownership of this domain) with service providers and even post-facto account suspensions due to old denylist data from various sources. Some databases recognize the domain as non-disposable, and some do not.

Perhaps express enumeration in the allowlist will help us.

If you are adding domains please state where one can generate a disposable email address which uses the added domains, so the maintainers can verify it. Without this information your PR will be closed.
