### PR TITLE
Add domains from tempmailo.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -609,6 +609,7 @@ chong-mail.net
 chong-mail.org
 chumpstakingdumps.com
 cigar-auctions.com
+citmo.net
 civikli.com
 civx.org
 ckaazaza.tk
@@ -621,9 +622,11 @@ classesmail.com
 clearwatermail.info
 click-email.com
 clickdeal.co
+clip.lat
 clipmail.eu
 clixser.com
 clonemoi.tk
+closetab.email
 cloud-mail.top
 cloudns.cx
 clout.wiki
@@ -1523,6 +1526,7 @@ ikbenspamvrij.nl
 ikuromi.com
 illistnoise.com
 ilovespam.com
+imagepoet.net
 imail1.net
 imails.info
 imailt.com
@@ -2450,6 +2454,7 @@ pe.hu
 pecinan.com
 pecinan.net
 pecinan.org
+pelagius.net
 penisgoes.in
 penoto.tk
 pepbot.com
@@ -2461,6 +2466,7 @@ pfui.ru
 phone-elkey.ru
 photo-impact.eu
 photomark.net
+physicalcloud.co
 pi.vu
 piaa.me
 pig.pp.ua
@@ -3333,6 +3339,7 @@ vda.ro
 vddaz.com
 vdig.com
 veanlo.com
+velvet-mag.lat
 vemomail.win
 venompen.com
 veo.kr


### PR DESCRIPTION
As see below, I managed to create an email on the `tempmailo.com` website for the `clip.lat` domain.

<img width="1003" alt="tempmailo-com" src="https://github.com/disposable-email-domains/disposable-email-domains/assets/716896/514c3846-22de-41ff-b79a-55689c4c8b5d">

The `clip.lat` domain resolves MX lookups to `mx2.den.yt.`, and so do the rest of the domains in this PR.