### PR TITLE
Add domains from 10minutemail.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -570,6 +570,9 @@ cashflow35.com
 casualdx.com
 catgroup.uk
 cavi.mx
+cazlg.com
+cazlp.com
+cazlv.com
 cbair.com
 cbes.net
 cc.liamria
@@ -613,6 +616,7 @@ civikli.com
 civx.org
 ckaazaza.tk
 ckiso.com
+ckptr.com
 cl-cl.org
 cl0ne.net
 claimab.com
@@ -694,6 +698,7 @@ cust.in
 cutout.club
 cutradition.com
 cuvox.de
+cwmxc.com
 cyber-innovation.club
 cyber-phone.eu
 cylab.org

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -572,6 +572,7 @@ catgroup.uk
 cavi.mx
 cazlg.com
 cazlp.com
+cazlq.com
 cazlv.com
 cbair.com
 cbes.net


### PR DESCRIPTION
As shown below, I managed to create an email address from the `10minutemail.com` website for the `cazlg.com` domain.

<img width="429" alt="10minutemail-com" src="https://github.com/disposable-email-domains/disposable-email-domains/assets/716896/4e0ad591-c5eb-48d2-aa24-a736959007f2">

The `cazlg.com` domain resolves MX lookups to `prd-smtp.10minutemail.com.`, and so do the rest of the domains in this PR. The following script can be used to validate the list:
```bash
#!/usr/bin/env bash
set -euo pipefail

PR="470"
PROVIDER="10minutemail.com"
MX_RECORDS=("prd-smtp.10minutemail.com.")

while read -r line; do
    echo "Checking $line"
    mx="$(dig +short MX "$line" | cut -d' ' -f2-)"
    grep_args=()
    for search_record in "${MX_RECORDS[@]}"; do
        grep_args+=('-e' "^${search_record//./\.}$")
    done
    grep -q "${grep_args[@]}" <<< "$mx" || echo "$line is not part of $PROVIDER (MX: $(paste -s -d' ' - <<< "${mx:-missing}"))"
done < <(curl -fsSL -o- https://github.com/disposable-email-domains/disposable-email-domains/pull/$PR.diff | grep '^+[^+]' | cut -d'+' -f2-)
```

Closes #429 
Closes #430 