### PR TITLE
Add additional alt domains for 1secmail.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -873,6 +873,7 @@ doublemail.de
 douchelounge.com
 dozvon-spb.ru
 dp76.com
+dpptd.com
 dr69.site
 drdrb.com
 drdrb.net
@@ -2724,6 +2725,7 @@ royalmarket.life
 royandk.com
 rppkn.com
 rsvhr.com
+rteet.com
 rtrtr.com
 rtskiya.xyz
 rudymail.ml


### PR DESCRIPTION
Add dpptd.com and rteet.com to the blocklist since they both redirect to https://www.1secmail.com/, which is on the blocklist
