### PR TITLE
Update disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -960,6 +960,7 @@ emailage.ml
 emailage.tk
 emailate.com
 emailbin.net
+emailcbox.pro
 emailcu.icu
 emaildienst.de
 emaildrop.io


### PR DESCRIPTION
https://github.com/disposable-email-domains/disposable-email-domains/issues/486

https://www.ipqualityscore.com/domain-reputation/emailcbox.pro

My site is full of fake users from this domain who are attempting to parse the content.

<img width="607" alt="Screenshot 2024-06-24 at 15 34 10" src="https://github.com/disposable-email-domains/disposable-email-domains/assets/3589618/c49e5502-4ef6-4dc7-aac8-3248835e1833">
