### PR TITLE
Add an additional temporary mail provider to the blocklist, 

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -701,6 +701,7 @@ cuirushi.org
 cuoly.com
 cupbest.com
 curlhph.tk
+currentmail.com
 curryworld.de
 cust.in
 cutout.club


### PR DESCRIPTION
This is an active site providing temporary email addresses
currentmail.com

The generated email addresses are on the `@currentmail.com` domain