### PR TITLE
feat: add bsidesmn.com domain

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -524,6 +524,7 @@ brefmail.com
 brennendesreich.de
 briggsmarcus.com
 broadbandninja.com
+bsidesmn.com
 bsnow.net
 bspamfree.org
 bspooky.com


### PR DESCRIPTION
Can be found in `temp-mail.org`.

Haven't seen any other PRs with this domain.

Evidence:
![image](https://github.com/disposable-email-domains/disposable-email-domains/assets/59324692/83863c1e-1c8e-410c-b15b-b06ad7e7f4ff)
