### PR TITLE
Removing aver(.)com as it's a legitimate company

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -395,7 +395,6 @@ autorobotica.com
 autosouvenir39.ru
 autotwollow.com
 autowb.com
-aver.com
 averdov.com
 avia-tonic.fr
 avls.pt


### PR DESCRIPTION
The aver(.)com domain is owned by Aver USA (https://www.averusa.com) which provides "visual collaboration solutions" (i.e. they make video conferencing products). Their support email is support.usa@aver.com. 