### PR TITLE
Add several additional disposable mail providers to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -701,6 +701,7 @@ cuirushi.org
 cuoly.com
 cupbest.com
 curlhph.tk
+currentmail.com
 curryworld.de
 cust.in
 cutout.club

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -673,6 +673,7 @@ copyhome.win
 coreclip.com
 cosmorph.com
 courrieltemporaire.com
+courrier.fr.cr
 coza.ro
 crankhole.com
 crapmail.org
@@ -1130,6 +1131,7 @@ fastkawasaki.com
 fastmazda.com
 fastmitsubishi.com
 fastnissan.com
+fastsearcher.com
 fastsubaru.com
 fastsuzuki.com
 fasttoyota.com
@@ -1157,6 +1159,7 @@ filbert4u.com
 filberts4u.com
 film-blog.biz
 filzmail.com
+finacenter.com
 findemail.info
 findu.pl
 finews.biz
@@ -1178,6 +1181,7 @@ fly-ts.de
 flyinggeek.net
 flymail.tk
 flyspam.com
+fmptestuje.pl
 fncp.ru
 fncp.store
 foobarbot.net
@@ -1219,6 +1223,7 @@ freemail.ms
 freemails.cf
 freemails.ga
 freemails.ml
+freemailzone.com
 freemeil.ga
 freemeil.gq
 freemeil.ml
@@ -1481,6 +1486,7 @@ hidemail.pro
 hidemail.us
 hidzz.com
 highbros.org
+highmail.my.id
 hiltonvr.com
 himail.online
 hmail.us
@@ -1896,6 +1902,7 @@ lr78.com
 lroid.com
 lru.me
 ls-server.ru
+lsh.my.id
 lsyx24.com
 luckymail.org
 lukecarriere.com
@@ -2166,6 +2173,7 @@ ministry-of-silly-walks.de
 minsmail.com
 mintemail.com
 mirai.re
+miramail.my.id
 misterpinball.de
 miucce.com
 mji.ro
@@ -2562,6 +2570,7 @@ postacin.com
 postbx.ru
 postbx.store
 postonline.me
+poubelle.fr.nf
 poutineyourface.com
 powered.name
 powerencry.com
@@ -3647,6 +3656,7 @@ xylar.store
 xyzfree.net
 xzsok.com
 yabai-oppai.tk
+yadim.dismail.de
 yahmail.top
 yahooproduct.net
 yamail.win


### PR DESCRIPTION
I've identified accounts created in some systems i'm working on using disposable email domains. Added them here with additional verification that these domains are providing disposable addresses

poubelle.fr.nf
https://www.ipqualityscore.com/domain-reputation/poubelle.fr.nf

lsh.my.id
https://www.ipqualityscore.com/domain-reputation/lsh.my.id

miramail.my.id
https://www.ipqualityscore.com/domain-reputation/miramail.my.id

yadim.dismail.de
Disposable mail service listed on https://dismail.de/

courrier.fr.cr
https://www.ipqualityscore.com/domain-reputation/courrier.fr.cr

fmptestuje.pl
Actively providing disposable emails from fmptestuje.pl

fastsearcher.com
https://www.ipqualityscore.com/domain-reputation/fastsearcher.com

freemailzone.com
https://www.ipqualityscore.com/domain-reputation/freemailzone.com

highmail.my.id
https://www.ipqualityscore.com/domain-reputation/highmail.my.id

finacenter.com
https://www.ipqualityscore.com/domain-reputation/finacenter.com