### PR TITLE
Add npm package link for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ async function isDisposable(email) {
 }
 ```
 
+Alternatively check out NPM package https://github.com/mziyut/disposable-email-domains-js.
+
 ### C#
 ```C#
 private static readonly Lazy<HashSet<string>> _emailBlockList = new Lazy<HashSet<string>>(() =>


### PR DESCRIPTION
This pull request adds a link to the npm package "disposable-email-domains-js" in the README.md file. This will provide users with an alternative way to access the package on GitHub.

I recently created an NPM package. I believe that linking it similarly to other languages and frameworks can help prevent the reinvention of the wheel.