### PR TITLE
Add a pointer to the resolve-email npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,10 @@ async function isDisposable(email) {
 }
 ```
 
-Alternatively check out NPM package https://github.com/mziyut/disposable-email-domains-js.
+Alternatively check out npm packages that use the list: 
+
+- [disposable-email-domains-js](https://github.com/mziyut/disposable-email-domains-js): Check email addresses and domains against the disposable-email-domains list.
+- [resolve-email](https://github.com/bcomnes/resolve-email): Check email addresses agains the disposable-email-domains domains list and check DNS resolution.
 
 ### C#
 ```C#


### PR DESCRIPTION
I integrated the disposable-email-domains into my email resolution module a while back and it is working well. I would love to add a pointer to it in the README here. I also added descriptions two the two links.

If you are adding domains please state where one can generate a disposable email address which uses the added domains, so the maintainers can verify it. Without this information your PR will be closed.
