### PR TITLE
Add bflcafe.com to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -460,6 +460,7 @@ bestparadize.com
 bestsoundeffects.com
 besttempmail.com
 betr.co
+bflcafe.com
 bgtmail.com
 bgx.ro
 bheps.com


### PR DESCRIPTION
I generated it at [Temp Mail](https://temp-mail.org/en/)
It can also be verified at https://verifymail.io/domain/bflcafe.com

Below is a screenshot of proof:
![Screenshot (201)](https://github.com/user-attachments/assets/e9acdda8-9852-4e5b-902a-2a30a732323d)

