### PR TITLE
Add confmin.com, cantozil.com and ytnhy.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -574,6 +574,7 @@ cam4you.cc
 camping-grill.info
 candymail.de
 cane.pw
+cantozil.com
 capitalistdilemma.com
 car101.pro
 carbtc.net
@@ -670,6 +671,7 @@ compareshippingrates.org
 completegolfswing.com
 comwest.de
 conf.work
+confmin.com
 consumerriot.com
 contbay.com
 cooh-2.site
@@ -3736,6 +3738,7 @@ yourtube.ml
 youxiang.dev
 yroid.com
 yspend.com
+ytnhy.com
 ytpayy.com
 yugasandrika.com
 yui.it


### PR DESCRIPTION
Adds `confmin.com` and `cantozil.com` from https://temp-mail.org/, and `ytnhy.com` from https://10minutemail.com/

![confmin-com](https://github.com/user-attachments/assets/e7ed01d0-de1d-4b38-9378-8edaccb0101a)
![cantozil-com](https://github.com/user-attachments/assets/69114514-0f23-4a63-a6dd-5d10b0477ae0)
![ytnhy-com](https://github.com/user-attachments/assets/abbb7120-4b84-4f81-85b8-d330bc9deee3)
