### PR TITLE
adding decep.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -806,6 +806,7 @@ deagot.com
 dealja.com
 deallabs.org
 dealrek.com
+decep.com
 deekayen.us
 defomail.com
 degradedfun.net


### PR DESCRIPTION
decep.com

https://www.usercheck.com/domain/decep.com

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
