### PR TITLE
Add More Spam Emails Identified in Production Applications

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -4018,3 +4018,7 @@ zyns.com
 zzi.us
 zzrgg.com
 zzz.com
+txt.att.net
+spam.xyz
+txt.bell.ca
+tmomail.net


### PR DESCRIPTION
The added emails were identified in spam logins on platforms in production in Brazil.

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
