### PR TITLE
Update disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1960,6 +1960,7 @@ landmail.co
 laoeq.com
 larisia.com
 larland.com
+lassora.com
 last-chance.pro
 laste.ml
 lastmail.co


### PR DESCRIPTION
Added lassora.com
Can be verified here:
https://verifymail.io/domain/lassora.com

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
