### PR TITLE
New domain from temp-mail.io

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2332,6 +2332,7 @@ mji.ro
 mjj.edu.ge
 mjukglass.nu
 mkpfilm.com
+mkzaso.com
 ml8.ca
 mliok.com
 mm.my


### PR DESCRIPTION
Found a new domain that is used by temp-mail.io

https://www.ipqualityscore.com/domain-reputation/mkzaso.com

![Screenshot from 2025-03-09 02-35-19](https://github.com/user-attachments/assets/bc2005a8-ea7a-44b1-ad62-b1410273b607)
