### PR TITLE
add citmo.net, dreamclarify.org, thetechnext.net from tempmailo.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -669,6 +669,7 @@ chophim.com
 chosenx.com
 chumpstakingdumps.com
 cigar-auctions.com
+citmo.net
 civikli.com
 civx.org
 ckaazaza.tk

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -949,6 +949,7 @@ dpptd.com
 dr69.site
 drdrb.com
 drdrb.net
+dreamclarify.org
 dred.ru
 drevo.si
 driftz.net
@@ -3439,6 +3440,7 @@ theroyalweb.club
 thescrappermovie.com
 thespamfather.com
 theteastory.info
+thetechnext.net
 thex.ro
 thichanthit.com
 thietbivanphong.asia


### PR DESCRIPTION
To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.

---

Adds `citmo.net`, `dreamclarify.org`, and `thetechnext.net` from tempmailo.com to the list.

They can be generated at https://tempmailo.com. Screenshots:

![image](https://github.com/user-attachments/assets/76244fa3-d85a-468f-8d17-f52156f62ab7)

![image](https://github.com/user-attachments/assets/5fa10e64-7cb4-4ebd-b732-0ef890d90b96)

![image](https://github.com/user-attachments/assets/b8cf7a0a-2dcc-41e1-9dcb-dffd25be09dd)

