### PR TITLE
Update disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2820,6 +2820,7 @@ psh.me
 psles.com
 psnator.com
 psoxs.com
+ptct.net
 ptsculure.com
 puglieisi.com
 puji.pro


### PR DESCRIPTION
Add ptct.net to blocklist

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
--------------------------------------------

Can be created via https://mail.tm/


<img width="1340" alt="Screenshot 2025-04-07 at 4 58 16 PM" src="https://github.com/user-attachments/assets/d49de7da-0e32-47b1-bb46-d1b313559f5f" />
