### PR TITLE
Add all "10minutemail.one" domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -729,6 +729,7 @@ cmail.club
 cmail.com
 cmail.net
 cmail.org
+cmdkl.com
 cmhvzylmfc.com
 cnamed.com
 cndps.com
@@ -751,6 +752,7 @@ coldemail.info
 compareshippingrates.org
 completegolfswing.com
 comwest.de
+comyze.org
 conf.work
 confmin.com
 consumerriot.com
@@ -2889,6 +2891,7 @@ ploae.com
 ploki.fr
 ploncy.com
 plw.me
+pngrise.com
 poehali-otdihat.ru
 pofmagic.com
 pojok.ml
@@ -3715,6 +3718,7 @@ tqosi.com
 trackden.com
 tradermail.info
 tranceversal.com
+translateid.com
 trap-mail.de
 trash-amil.com
 trash-mail.at


### PR DESCRIPTION
All domains for "10minutemail.one" are not listed directly on the page but can be viewed by clicking the "Change" button on https://10minutemail.one/. Each domain uses the IP address `51.79.50.159` and is hosted on `OVH SAS (AS16276)`. Below, I’ve included one screenshot for each domain in the list.

- cmdkl.com
<img width="736" alt="image" src="https://github.com/user-attachments/assets/05d5e07f-e80c-4893-835e-8438784db636" />

- comyze.org
<img width="740" alt="image" src="https://github.com/user-attachments/assets/a2448b17-e5f7-44d2-ba15-07e83e13f01b" />

- pngrise.com
<img width="738" alt="image" src="https://github.com/user-attachments/assets/1cf78365-1fe6-4b76-8119-2fa767639e7f" />

- translateid.com
<img width="738" alt="image" src="https://github.com/user-attachments/assets/c8e85ffd-ec9f-4227-b36f-501304ab4112" />