### PR TITLE
Add all "awamail.com" and "linshi-email.com" domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -439,6 +439,7 @@ averdov.com
 avia-tonic.fr
 avls.pt
 avtolev.com
+awa.pics
 awatum.de
 awdrt.org
 awesome47.com

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1885,6 +1885,7 @@ itunesgiftcodegenerator.com
 iuanhoi.store
 iubridge.com
 iuemail.men
+iwatermail.com
 iwi.net
 ixaks.com
 ixhale.com
@@ -3157,6 +3158,7 @@ satisfyme.club
 satukosong.com
 sausen.com
 savests.com
+say0.com
 saynotospams.com
 scatmail.com
 scay.net
@@ -3907,6 +3909,7 @@ vintomaper.com
 vipepe.com
 vipmail.name
 vipmail.pw
+vips.pics
 vipxm.net
 viralplays.com
 virtualemail.info
@@ -4200,6 +4203,7 @@ ytnhy.com
 ytpayy.com
 yugasandrika.com
 yui.it
+yun.pics
 yuoia.com
 yuurok.com
 ywzmb.top


### PR DESCRIPTION
linshi-email.com and awamail.com don’t show all domains at once. 
you have to click the change button to refresh them. I’ve attached screenshots of all the domains below.

awamail.com:

- say0.com
![ebc9d6f1-da26-49ba-b053-aa6e2546f652](https://github.com/user-attachments/assets/30b785e8-cf1b-4cdf-9936-1d448a578494)

- yun.pics
![ae005d2b-6f15-4053-a9d6-afc6a33c013a](https://github.com/user-attachments/assets/c60b6176-846b-4867-a542-de47f97dba99)

- awa.pics
![image](https://github.com/user-attachments/assets/64fbf639-e831-4b27-bb9f-c03e9a06336d)

- vips.pics
![image](https://github.com/user-attachments/assets/06c24697-fba3-4d0a-9ad6-3feb151dfc57)

linshi-email.com:

- iwatermail.com
![0fc89898-58f0-4d69-bbaf-2743ac028dc6](https://github.com/user-attachments/assets/f092961c-6b76-463b-8db2-bbb4e169708a)