### PR TITLE
Add all "tempmail.now" domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1327,6 +1327,7 @@ findu.pl
 finews.biz
 fingso.com
 fir.hk
+fira.my
 firemailbox.club
 fitnesrezink.ru
 fivemail.de
@@ -1435,6 +1436,7 @@ fux0ringduh.com
 fxnxs.com
 fxtubes.com
 fyii.de
+fynix.sbs
 g14l71lb.com
 g1xmail.top
 g2xmail.top
@@ -1716,6 +1718,7 @@ hs.vc
 hsmw.net
 ht.cx
 hthlm.com
+httpsgreenwichmeantime.in
 huangniu8.com
 huizk.com
 hukkmu.tk
@@ -2164,11 +2167,13 @@ luckymail.org
 lukecarriere.com
 lukemail.info
 lukop.dk
+lunor.cfd
 lushosa.com
 luv2.us
 lydir.com
 lyfestylecreditsolutions.com
 lyft.live
+lynex.sbs
 lyricspad.net
 lzoaq.com
 m21.cc
@@ -3888,7 +3893,9 @@ veryday.info
 veryrealemail.com
 ves.ink
 vesa.pw
+vetra.cyou
 vevs.de
+vexi.my
 via.tokyo.jp
 vibzi.net
 vickaentb.tk
@@ -3963,6 +3970,7 @@ vtxmail.us
 vubby.com
 vuiy.pw
 vuket.org
+vulca.sbs
 vusra.com
 vvatxiy.com
 vwhins.com
@@ -4112,6 +4120,7 @@ xcoxc.com
 xcpy.com
 xemaps.com
 xemne.com
+xenta.cfd
 xents.com
 xepa.ru
 xidealx.com
@@ -4241,7 +4250,9 @@ zipcatfish.com
 zipo1.gq
 zippymail.info
 zipsendtest.com
+zira.my
 ziragold.com
+zivox.sbs
 zizo7.com
 zoaxe.com
 zoemail.com


### PR DESCRIPTION
All domains for "tempmail.now" are not listed directly on the page but can be viewed by clicking the "Change Email" button on https://tempmail.now/. Each domain uses the IP address `167.71.185.60` and is hosted on `DigitalOcean, LLC (AS14061)`. Below, I’ve included one screenshot for each domain in the list.

- fira.my
<img width="800" alt="image" src="https://github.com/user-attachments/assets/bd751781-2072-4e64-b604-b996e169f632" />

- fynix.sbs
<img width="801" alt="image" src="https://github.com/user-attachments/assets/fb142431-b28d-459f-8b0f-7260956f4dd8" />

- httpsgreenwichmeantime.in
<img width="802" alt="image" src="https://github.com/user-attachments/assets/cc223c16-f8d6-4ac5-b872-58704960eba5" />

- lunor.cfd
<img width="800" alt="image" src="https://github.com/user-attachments/assets/a642c70a-f28c-4d5c-8648-d08d72aa227a" />

- lynex.sbs
<img width="802" alt="image" src="https://github.com/user-attachments/assets/35df10c8-6d46-4c32-b1a3-55f877898fc1" />

- vetra.cyou
<img width="801" alt="image" src="https://github.com/user-attachments/assets/57c10d98-e8f9-41f5-b56c-f8ce67101b7f" />

- vexi.my
<img width="799" alt="image" src="https://github.com/user-attachments/assets/1e0b8a1c-c391-46f7-a592-2a18b811fd59" />

- vulca.sbs
<img width="801" alt="image" src="https://github.com/user-attachments/assets/90a9a1a3-7446-442b-b5ea-9546291b2906" />

- xenta.cfd
<img width="800" alt="image" src="https://github.com/user-attachments/assets/bb9ae974-8ac8-4637-a287-98c112735445" />

- zira.my
<img width="801" alt="image" src="https://github.com/user-attachments/assets/d3e550bb-e500-405c-be4d-7d5e04685761" />

- zivox.sbs
<img width="800" alt="image" src="https://github.com/user-attachments/assets/896c1ddd-b570-49e0-af26-168aba0c97e3" />