### PR TITLE
Add all "mailbox49.com" domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -262,7 +262,9 @@ affluentwe.us
 affordablewe.us
 afia.pro
 afrobacon.com
+aftercorporation.com
 afterhourswe.us
+afternea.sbs
 agedmail.com
 agendawe.us
 agger.ro
@@ -349,6 +351,7 @@ amelabs.com
 americanawe.us
 americasbestwe.us
 americaswe.us
+amex409.monster
 amicuswe.us
 amilegit.com
 amiri.net
@@ -380,6 +383,7 @@ anonymbox.com
 anonymized.org
 anonymousness.com
 anotherdomaincyka.tk
+anquandx.com
 ansibleemail.com
 anthony-junkmail.com
 antireg.com
@@ -559,6 +563,7 @@ bofthew.com
 bonobo.email
 boofx.com
 bookthemmore.com
+bootssl.com
 bootybay.de
 borged.com
 borged.net
@@ -674,6 +679,7 @@ cellurl.com
 cengrop.com
 centermail.com
 centermail.net
+certificenter.com
 cetpass.com
 cfo2go.ro
 ch.ma
@@ -685,6 +691,7 @@ chansd.com
 chapsmail.com
 chasefreedomactivate.com
 chatich.com
+chatworkstation.com
 cheaphub.net
 cheatmail.de
 chenbot.email
@@ -750,6 +757,7 @@ cobarekyo1.ml
 cocoro.uk
 cocovpn.com
 codeandscotch.com
+codeguard.net
 codivide.com
 coffeetimer24.com
 coieo.com
@@ -1037,6 +1045,7 @@ dumpmail.de
 dumpyemail.com
 durandinterstellar.com
 duskmail.com
+dusrui.com
 dvdpit.com
 dwse.edu.pl
 dyceroprojects.com
@@ -1984,6 +1993,7 @@ kaspop.com
 katztube.com
 kazelink.ml
 kbox.li
+kcoporation.com
 kcrw.de
 kd2.org
 keepmymail.com
@@ -2242,6 +2252,7 @@ mailbiz.biz
 mailblocks.com
 mailbox.in.ua
 mailbox.zip
+mailbox49.com
 mailbox52.ga
 mailbox80.biz
 mailbox82.biz
@@ -2835,6 +2846,7 @@ owlpic.com
 ownsyou.de
 owube.com
 oxfo.edu.pl
+oxmail.homes
 oxopoha.com
 ozatvn.com
 ozm.fr
@@ -3004,6 +3016,7 @@ puttanamaiala.tk
 putthisinyourspamdatabase.com
 pwpwa.com
 pwrby.com
+pyskillsgame.com
 qabq.com
 qacmjeq.com
 qasti.com
@@ -3590,6 +3603,7 @@ tempmaildemo.com
 tempmailer.com
 tempmailer.de
 tempmailer.net
+tempmailfree.net
 tempmailo.com
 tempmailyo.org
 tempomail.fr
@@ -3614,6 +3628,7 @@ ternaklele.ga
 testore.co
 testudine.com
 tevstart.com
+tgduck.com
 thanksnospam.info
 thankyou2010.com
 thatim.info


### PR DESCRIPTION
All domains for "mailbox49.com" are not listed directly on the page but can be viewed by clicking the "Change Address" button on https://mailbox49.com/en. Each domain uses the IP address `134.195.211.168` and is hosted on `MULTACOM CORPORATION (AS35916)`. Below, I’ve included one screenshot for each domain in the list.

> Note: The domain amex409.monster and oxmail.homes have no MX record but I added them to the commit because in the site they are shown as domains to generate mails which means that at any time they can add MX records to them.

- dusrui.com
<img width="839" alt="dusrui com" src="https://github.com/user-attachments/assets/e97b3f08-8b5e-4e76-a199-69123ea2a83e" />

- anquandx.com
<img width="839" alt="anquandx com" src="https://github.com/user-attachments/assets/b0fb378d-d5cd-4e0a-bcf5-b893fe03902e" />

- tempmailfree.net
<img width="840" alt="tempmailfree net" src="https://github.com/user-attachments/assets/59b8e52a-ab54-4f50-ad6f-30c43c8fed82" />

- amex409.monster
<img width="840" alt="amex409 monster" src="https://github.com/user-attachments/assets/623daabe-e86d-431d-b8fe-544193f8f5fa" />

- tgduck.com
<img width="840" alt="tgduck com" src="https://github.com/user-attachments/assets/728c085d-281a-43cc-b71b-f8da9140bdf1" />

- mailbox49.com
<img width="839" alt="mailbox49 com" src="https://github.com/user-attachments/assets/907a8f6b-7e2d-4fb3-962f-8f38bec6ecf5" />

- chatworkstation.com
<img width="842" alt="chatworkstation com" src="https://github.com/user-attachments/assets/1d62ff63-94e5-47cb-ad4b-30bbbcb1337e" />

- oxmail.homes
<img width="841" alt="oxmail homes" src="https://github.com/user-attachments/assets/8f8663cd-9f00-4d66-ba99-67c3067dd4c2" />

- bootssl.com
<img width="841" alt="bootssl com" src="https://github.com/user-attachments/assets/058f9f8c-9ad5-4542-bf11-46b2109f610f" />

- kcoporation.com
<img width="841" alt="kcoporation com" src="https://github.com/user-attachments/assets/07a87384-bdc7-4db5-87b8-37b4d3c161c5" />

- afternea.sbs
<img width="840" alt="afternea sbs" src="https://github.com/user-attachments/assets/8ef2cf9f-2f11-430a-9055-c776eeddd037" />

- codeguard.net
<img width="841" alt="codeguard net" src="https://github.com/user-attachments/assets/388e414c-0a50-4a9a-9196-20eb759d3b46" />

- certificenter.com
<img width="841" alt="certificenter com" src="https://github.com/user-attachments/assets/c3cacab5-e1e3-49b8-a7f6-8d282952381b" />

- pyskillsgame.com
<img width="839" alt="pyskillsgame com" src="https://github.com/user-attachments/assets/45167458-9a75-4a12-a8f2-3bdf1f9adfb5" />

- aftercorporation.com
<img width="841" alt="aftercorporation com" src="https://github.com/user-attachments/assets/041a6aaa-d078-408a-b151-d9385bfd82f9" />