### PR TITLE
Add all "22.do" domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -763,6 +763,8 @@ coffeetimer24.com
 coieo.com
 coin-host.net
 coinlink.club
+colabeta.com
+colaname.com
 coldemail.info
 compareshippingrates.org
 completegolfswing.com
@@ -1328,6 +1330,7 @@ fexbox.org
 fexbox.ru
 fexpost.com
 fextemp.com
+fft.edu.do
 ficken.de
 fictionsite.com
 fightallspam.com
@@ -3711,6 +3714,7 @@ tmpmail.org
 tmpmailtor.com
 tmpnator.live
 tmpx.sa.com
+tnbeta.com
 toddsbighug.com
 tofeat.com
 tohru.org
@@ -3876,6 +3880,7 @@ us.to
 usa.cc
 usako.net
 usbc.be
+usdtbeta.com
 used-product.fr
 ushijima1129.cf
 ushijima1129.ga


### PR DESCRIPTION
All domains for "22.do" appear directly on the page, which can be viewed by clicking on the dropdown that displays the domains at https://22.do/. Each domain is hosted by `Cloudflare, Inc. (AS13335)`. Below, I have included a screenshot for each domain in the list.

> Note: The linshiyou.com and youxiang.dev domains are also from this provider but are already added to the repository.

- All domains
![image](https://github.com/user-attachments/assets/c281d5b3-4cb5-4ac3-9435-eba96d5fd04c)