### PR TITLE
Update allowlist.conf

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -19,6 +19,7 @@ antichef.com
 antichef.net
 bestmail.us
 bluewin.ch
+belt.io
 c2.hu
 cluemail.com
 cocaine.ninja


### PR DESCRIPTION
I’ve added our domain, belt.io. We are a Delaware-registered SaaS company, and we purchased this domain online in 2022. Unfortunately, it appears that our domain is currently marked as a disposable domain on a few websites.

The only explanation we can think of is that the domain may have previously belonged to a marketing startup, and some of their digital footprint might still be associated with it.

We would greatly appreciate it if you could review and approve this PR. Let me know if any additional information is needed

Thanks 
Sheetal 
cto 
belt software inc
https://www.linkedin.com/in/taljain/
+1 (773) 715 7435
sheetal.jain@belt.io

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
