### PR TITLE
Add all "tempmail.pw" domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -253,6 +253,7 @@ aegiswe.us
 aelo.es
 aeonpsi.com
 afarek.com
+afeeyah.store
 affiliate-nebenjob.info
 affiliatedwe.us
 affilikingz.de
@@ -701,6 +702,7 @@ chielo.com
 childsavetrust.org
 chilkat.com
 chinamkm.com
+chingchongme.site
 chithinh.com
 chitthi.in
 choco.la
@@ -1906,7 +1908,9 @@ irssi.tv
 is.af
 isdaq.com
 ishop2k.com
+ismartsense.online
 isosq.com
+ispeedtest.digital
 ist-hier.com
 istii.ro
 isukrainestillacountry.com
@@ -1934,6 +1938,7 @@ jakemsr.com
 janproz.com
 japnc.com
 jaqis.com
+jasonbella.online
 javadmin.com
 jdmadventures.com
 jdz.ro
@@ -2638,6 +2643,7 @@ n1nja.org
 na-cat.com
 naah.ru
 naah.store
+nabaxox.edu.pl
 nabuma.com
 nada.email
 nada.ltd
@@ -3145,6 +3151,7 @@ rhyta.com
 richfinances.pw
 riddermark.de
 rifkian.ga
+rimshacooking.site
 rinseart.com
 rippb.com
 risingsuntouch.com
@@ -3238,6 +3245,7 @@ secure-mail.biz
 secure-mail.cc
 secured-link.net
 securehost.com.es
+seedspeed.site
 seekapps.com
 seekjobs4u.com
 sehier.fr
@@ -3307,6 +3315,7 @@ silvercoin.life
 sim-simka.ru
 simaenaga.com
 simpleitsecurity.info
+simranaitech.space
 sin.cl
 sinaite.net
 sind-hier.com


### PR DESCRIPTION
All domains for "tempmail.pw" appear directly on the page, which can be viewed by clicking the "Select Domain" dropdown on https://tempmail.pw/change. Each domain is hosted by `Cloudflare, Inc. (AS13335)`. Below, I’ve included the screenshot.

- All domains
![image](https://github.com/user-attachments/assets/58a5c932-3b85-436c-a17e-1208f771b0bd)