### PR TITLE
feat(domains): Add freetempmail.org domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -566,6 +566,7 @@ boofx.com
 bookthemmore.com
 bootssl.com
 bootybay.de
+bored.lol
 borged.com
 borged.net
 borged.org
@@ -1377,6 +1378,7 @@ flyspam.com
 flyzy.net
 fncp.ru
 fncp.store
+fog.one
 foobarbot.net
 footard.com
 foreastate.com
@@ -1569,6 +1571,7 @@ gmx1mail.top
 gmxmail.top
 gmxmail.win
 gnctr-calgary.com
+gni8.com
 go2usa.info
 go2vpn.net
 goatmail.uk
@@ -2033,6 +2036,7 @@ kiani.com
 kidaroa.com
 killmail.com
 killmail.net
+killyourtime.com
 kimsdisk.com
 kinda.email
 kindamail.com
@@ -3893,6 +3897,7 @@ ucche.us
 ucupdong.ml
 uemail99.com
 ufacturing.com
+ug.wtf
 uggsrock.com
 uguuchantele.com
 uhe2.com


### PR DESCRIPTION
All domains for "freetempmail.org" are not listed directly on the page but can be viewed by clicking the "Change Email" button on https://www.freetempmail.org/. Each domain is hosted by `Cloudflare, Inc. (AS13335)`. Below, I have included a screenshot for each domain in the list.

- bored.lol
![image](https://github.com/user-attachments/assets/f519c289-dcc5-4ac4-92bb-c3fdbedd1c85)

- fog.one
![image](https://github.com/user-attachments/assets/1ac7daf0-1ff2-4618-b7da-06e55a2f8b5d)

- gni8.com
![image](https://github.com/user-attachments/assets/62117415-0b3c-4ed1-aca6-7cfaaa15e5f9)

- killyourtime.com
![image](https://github.com/user-attachments/assets/5b241536-a9e0-4ba2-bfbf-66dfe6bca285)

- ug.wtf
![image](https://github.com/user-attachments/assets/8b94eec8-afd1-4c83-95f9-1560ca29f171)