### PR TITLE
feat(domains): Add adguard.com temp mail domain

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2154,6 +2154,7 @@ lerany.com
 lerbhe.com
 lerch.ovh
 lero3.com
+letterprotect.net
 letthemeatspam.com
 lez.se
 lgxscreen.com


### PR DESCRIPTION
This is a domain from adguard's free temp mail service

![image](https://github.com/user-attachments/assets/537f4aad-79d9-4f62-81e5-feba9fb59357)
https://adguard.com/en/adguard-temp-mail/overview.html