### PR TITLE
Domains used by nospam.today

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1944,6 +1944,7 @@ j-p.us
 jafps.com
 jaga.email
 jailbreakeverything.com
+jaipas.lu
 jajxz.com
 jakemsr.com
 janproz.com
@@ -2754,6 +2755,7 @@ noreply.fr
 nori24.tv
 norseforce.com
 norwegischlernen.info
+nospam.today
 nospam4.us
 nospamfor.us
 nospamthanks.info
@@ -2822,6 +2824,7 @@ oloh.ru
 oloh.store
 olypmall.ru
 omail.pro
+omfg.run
 omnievents.org
 omtecha.com
 one-mail.top
@@ -2835,6 +2838,7 @@ oneoffmail.com
 onetm-ml.com
 onetm.jp
 onewaymail.com
+onheb.com
 onionred.com
 onlatedotcom.info
 online.ms
@@ -2913,6 +2917,7 @@ pavilionx2.com
 payperex2.com
 payspun.com
 pe.hu
+peakinbox.net
 pecinan.com
 pecinan.net
 pecinan.org
@@ -3016,6 +3021,7 @@ primabananen.net
 prin.be
 privacy-mail.top
 privacy.net
+privacyshield.cc
 privatdemail.net
 privmail.edu.pl
 privy-mail.com
@@ -3042,6 +3048,7 @@ proprietativalcea.ro
 propscore.com
 protempmail.com
 prout.be
+proxy-gateway.net
 proxymail.eu
 proxyparking.com
 prtnx.com


### PR DESCRIPTION
Domains used by https://nospam.today/ 
![image](https://github.com/user-attachments/assets/c9b5929b-0817-4d37-b1ba-75709178c127)
