### PR TITLE
feat(lists): add temp-mail.best domain

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3652,6 +3652,7 @@ tellos.xyz
 telvetto.com
 teml.net
 temp-link.net
+temp-mail.best
 temp-mail.cfd
 temp-mail.com
 temp-mail.de


### PR DESCRIPTION
When entering https://temp-mail.best/ the only domain that appears is `temp-mail.best` when generating a new address.

- temp-mail.best
![image](https://github.com/user-attachments/assets/87932b56-3be1-4656-ba10-b0de1927442d)