### PR TITLE
chore: add a new disposable domain from temp-mail.org

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -595,6 +595,7 @@ boxformail.in
 boximail.com
 boxlet.ru
 boxlet.store
+boxmach.com
 boxmail.lol
 boxomail.live
 boxtemp.com.br


### PR DESCRIPTION
You can generate the domain by going to [temp-mail](https://temp-mail.org/en/)


![Screenshot 2025-06-30 at 15 50 38](https://github.com/user-attachments/assets/112c8218-28fb-4444-a3f6-eb37e08d7e9a)
