### PR TITLE
feat(domains): add edumail.icu domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -414,6 +414,7 @@ appzily.com
 aprte.com
 arcadein.com
 arduino.hk
+ares.edu.pl
 ariaz.jetzt
 armyspy.com
 aron.us
@@ -499,6 +500,7 @@ bcaoo.com
 bcast.ws
 bcb.ro
 bccto.me
+bcm.edu.pl
 bcooq.com
 bdm.ovh
 bdmuzic.pw
@@ -1104,6 +1106,7 @@ ecstor.com
 edgex.ru
 edinburgh-airporthotels.com
 edumail.edu.pl
+edumail.edu.rs
 edupolska.edu.pl
 edv.to
 ee1.pl
@@ -1347,6 +1350,7 @@ fastchevy.com
 fastchrysler.com
 fasternet.biz
 fastkawasaki.com
+fastmail.edu.pl
 fastmazda.com
 fastmitsubishi.com
 fastnissan.com
@@ -1607,12 +1611,14 @@ gmx1mail.top
 gmxmail.top
 gmxmail.win
 gnctr-calgary.com
+gng.edu.pl
 gni8.com
 go2usa.info
 go2vpn.net
 goatmail.uk
 godfare.com
 goemailgo.com
+gold.edu.pl
 golemico.com
 gomail.in
 gonida.co.uk
@@ -4035,6 +4041,7 @@ usm.ovh
 utiket.us
 uu.gl
 uu2.ovh
+uue.edu.pl
 uuf.me
 uuii.in
 uwork4.us


### PR DESCRIPTION
All domains can be viewed by going to https://edumail.icu/ and clicking on “Domain Dropdown”.

> This commit includes second-level domains.

![image](https://github.com/user-attachments/assets/658029a5-555f-4dea-a0e8-14ffd2979a2b)