### PR TITLE
move manybrain.com from disposable to allow. It is the company that o…

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -117,6 +117,7 @@ mailsent.net
 mailservice.ms
 mailup.net
 mailworks.org
+manybrain.com
 memeware.net
 ml1.net
 mm.st

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2517,7 +2517,6 @@ mandraghen.cf
 manifestgenerator.com
 mannawo.com
 mansiondev.com
-manybrain.com
 mark-compressoren.ru
 marketlink.info
 markmurfin.com


### PR DESCRIPTION
Manybrain is a Company that owns Mailinator, but the domain manybrain.com is for company employees - it is not disposable.  This can be verified by emailing support@manybrain.com (which will work and be replied to), and trying to email something random (xyz123@manybrain.com) which won't work.

<img width="800" height="469" alt="image" src="https://github.com/user-attachments/assets/a10aaa09-e25b-48d8-ab74-b04b008084e1" />

