### PR TITLE
Update disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -785,6 +785,7 @@ cocoro.uk
 cocovpn.com
 codeandscotch.com
 codeguard.net
+coderdir.com
 codestar.site
 codivide.com
 coffeetimer24.com


### PR DESCRIPTION
In use by temp-mail.org

<img width="698" height="467" alt="image" src="https://github.com/user-attachments/assets/de720d0c-2666-408f-9598-2e8f0816d189" />
