### PR TITLE
Add sites associated with quix.email

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -478,6 +478,7 @@ b2bx.net
 b2cmail.de
 b7s.ru
 backilnge.com
+bacteroidmail.com
 badgerland.eu
 badoop.com
 badpotato.tk
@@ -509,6 +510,7 @@ bdm.ovh
 bdmuzic.pw
 beaconmessenger.com
 bearsarefuzzy.com
+beastmail.space
 beddly.com
 beefmilk.com
 belamail.org
@@ -580,6 +582,7 @@ bobgf.ru
 bobgf.store
 bobmail.info
 bobmurchison.com
+boerakemail.com
 bofthew.com
 bonobo.email
 boofx.com
@@ -795,6 +798,7 @@ colabeta.com
 colaname.com
 coldemail.info
 collegewh.edu.pl
+colorcastmail.com
 compareshippingrates.org
 completegolfswing.com
 comwest.de
@@ -924,10 +928,12 @@ delayload.net
 delikkt.de
 delivrmail.com
 delorex.com
+deluxmail.com
 demen.ml
 dengekibunko.ga
 dengekibunko.gq
 dengekibunko.ml
+deornaumail.com
 der-kombi.de
 derkombi.de
 derluxuswagen.de
@@ -1037,6 +1043,7 @@ dontsendmespam.de
 doobb.com
 doojazz.com
 doquier.tk
+dotapodemail.com
 dotman.de
 dotmsg.com
 dotslashrage.com
@@ -1377,6 +1384,7 @@ fdfdsfds.com
 featcore.com
 femailtor.com
 fer-gabon.org
+ferdomnermail.com
 fermaxxi.ru
 feroxid.com
 fettometern.com
@@ -1540,6 +1548,7 @@ gassmail.com
 gasuda.com
 gav0.com
 gawab.com
+gaxetovemail.com
 gbcmail.win
 gbmail.top
 gcmail.top
@@ -2220,8 +2229,10 @@ lerany.com
 lerbhe.com
 lerch.ovh
 lero3.com
+lesobprovermail.com
 letterhaven.net
 letterprotect.net
+lettersboxmail.com
 letthemeatspam.com
 lez.se
 lgxscreen.com
@@ -2585,6 +2596,7 @@ migumail.com
 mihep.com
 miistermail.fr
 mijnhva.nl
+minefieldmail.com
 minimail.gq
 ministry-of-silly-walks.de
 minsmail.com
@@ -2699,6 +2711,7 @@ myindohome.services
 myinfoinc.com
 myinterserver.ml
 mykickassideas.com
+myletters.online
 mymail-in.net
 mymail90.com
 mymailoasis.com
@@ -2816,6 +2829,7 @@ noicd.com
 nokdot.com
 nokiamail.com
 nolemail.ga
+nolettersbox.com
 nomail.cf
 nomail.ga
 nomail.pw
@@ -2835,9 +2849,11 @@ nospam.today
 nospam4.us
 nospamfor.us
 nospamthanks.info
+notboxletters.com
 nothingtoseehere.ca
 notif.me
 notipr.com
+notlettersmail.com
 notmailinator.com
 notrnailinator.com
 notsharingmy.info
@@ -2911,6 +2927,7 @@ one-sec-mail.site
 one-time.email
 one2mail.info
 onekisspresave.com
+onelettersmail.com
 onemail.host
 oneoffemail.com
 oneoffmail.com
@@ -2953,6 +2970,7 @@ orgmbx.cc
 oroki.de
 oronny.com
 orsbap.com
+ortogenmail.com
 oshietechan.link
 ostinmail.com
 osxofulk.com
@@ -3016,6 +3034,7 @@ phamay.com
 phone-elkey.ru
 photo-impact.eu
 photomark.net
+physcroenmail.com
 pi.vu
 piaa.me
 pig.pp.ua
@@ -3972,8 +3991,10 @@ trickmail.net
 trillianpro.com
 triots.com
 trixtrux1.ru
+trolebrotmail.com
 trollproject.com
 tropicalbass.info
+tropovenamail.com
 trungtamtoeic.com
 truthfinderlogin.com
 tryalert.com
@@ -4011,6 +4032,7 @@ ucche.us
 ucupdong.ml
 uemail99.com
 ufacturing.com
+ufokeuabmail.com
 ug.wtf
 uggsrock.com
 uguuchantele.com
@@ -4097,6 +4119,7 @@ vercelli.gq
 vercelli.ml
 verdejo.com
 vermutlich.net
+veruvercomail.com
 veryday.ch
 veryday.eu
 veryday.info
@@ -4460,6 +4483,7 @@ zehnminuten.de
 zehnminutenmail.de
 zemzar.net
 zepp.dk
+zeronerbacomail.com
 zetmail.com
 zfymail.com
 zhaoqian.ninja


### PR DESCRIPTION
We've seen spam/abuse behavior and mass automated account creation attempts from these email domains at Stytch. 

You can purchase disposable emails from these domains via https://quix.email ([FAQ](https://quix.email/faq)). I've filtered out those from commonly-used free domains like Gmail and Hotmail. 

<img width="1027" height="353" alt="image" src="https://github.com/user-attachments/assets/a0fa41a3-55ba-4290-aa05-092ffc45b808" />

<img width="520" height="931" alt="image" src="https://github.com/user-attachments/assets/f293ac5c-d3a8-458c-974b-54739206cb49" />

