### PR TITLE
Add jobzyy.com to disposable email domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2084,6 +2084,7 @@ justemail.ml
 juyouxi.com
 jwork.ru
 jxpomup.com
+jobzyy.com
 kabamail.com
 kademen.com
 kadokawa.cf

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2063,6 +2063,7 @@ jobbikszimpatizans.hu
 jobbrett.com
 jobposts.net
 jobs-to-be-done.net
+jobzyy.com
 joelpet.com
 joetestalot.com
 jofuso.com
@@ -2084,7 +2085,6 @@ justemail.ml
 juyouxi.com
 jwork.ru
 jxpomup.com
-jobzyy.com
 kabamail.com
 kademen.com
 kadokawa.cf


### PR DESCRIPTION
This PR adds the jobzyy.com domain, generated from [Temp-Mail](https://temp-mail.org/en/), to the disposable email domains list. This domain was not previously included.
<img width="1147" height="506" alt="image" src="https://github.com/user-attachments/assets/984e1409-ac8e-4658-bcf7-764da8e7e68f" />
