### PR TITLE
Add newaddr.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2912,6 +2912,7 @@ netris.net
 netviewer-france.com
 netzidiot.de
 nevermail.de
+newaddr.com
 newbpotato.tk
 newfilm24.ru
 newideasfornewpeople.info


### PR DESCRIPTION

newaddr.com - abuse link on homepage goes to https://magical.kuku.lu/page.contact.php?type=MailNow which is the support form for InstAddr, a disposable email provider.

<img width="686" height="242" alt="image" src="https://github.com/user-attachments/assets/9c434a17-4e1a-4563-a083-fb7f603100a4" />

<img width="1243" height="574" alt="image" src="https://github.com/user-attachments/assets/908f0a3d-63d6-4106-a65f-712be3601797" />

http://133.130.102.20/ (MX record IP) redirects to https://m.kuku.lu/en.php also.
