### PR TITLE
Update Python Example to Handle Third Level Domains and Higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ for i in range(len(domain_parts) - 1):
     if ".".join(domain_parts[i:]) in blocklist_content:
         message = "Please enter your permanent email address."
         return (False, message)
-        
 return True
 ```
 


### PR DESCRIPTION
### Proposal
- Add a new blocklist to check against wildcard domains
- Update the verify.py script to filter against the public suffix list (e.g. *.co.uk)
- Update the README.md to provide a basic python example of how the new blocklist can be used. Happy to update a couple of the other language examples that I am comfortable with if this is accepted

Fixes #759 
