### PR TITLE
Add new disposable email domains: appmail.uk, dakaka.org, momoi.uk

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -418,6 +418,7 @@ apkmd.com
 appc.se
 appinventor.nl
 appixie.com
+appmail.uk
 apps.dj
 appzily.com
 aprte.com
@@ -910,6 +911,7 @@ daemsteam.com
 daibond.info
 daily-email.com
 daintly.com
+dakaka.org
 damai.webcam
 dammexe.net
 damnthespam.com
@@ -2767,6 +2769,7 @@ mohmal.tech
 moimoi.re
 molms.com
 momentics.ru
+momoi.uk
 mona.edu.kg
 mona.edu.pl
 monachat.tk


### PR DESCRIPTION
I'd like to register the following three domains:

- appmail.uk
- dakaka.org
- momoi.uk

These domains are available as shown in the screenshot at the following URL: https://m.kuku.lu/ja.php#p868

<img width="500" height="1016" alt="disposable_mail_domains_screen_shot" src="https://github.com/user-attachments/assets/726ace23-ddce-470c-994e-dc2fadfef502" />

Thanks to the maintainers for providing this list to people.
