### PR TITLE
Add apocaw.com to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -415,6 +415,7 @@ aoeuhtns.com
 apfelkorps.de
 aphlog.com
 apkmd.com
+apocaw.com
 appc.se
 appinventor.nl
 appixie.com


### PR DESCRIPTION
This email address can be generated from the website temp-mail.org/

<img width="1853" height="512" alt="apocaw-temp-mail" src="https://github.com/user-attachments/assets/cbdbe04b-6aa2-4648-9094-ba39c2c0c697" />
