### PR TITLE
fix: remove gynzy domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1807,16 +1807,6 @@ guysmail.com
 gxemail.men
 gynzi.co.uk
 gynzi.es
-gynzy.at
-gynzy.es
-gynzy.eu
-gynzy.gr
-gynzy.info
-gynzy.lt
-gynzy.mobi
-gynzy.pl
-gynzy.ro
-gynzy.sk
 gzb.ro
 h0tmaii.com
 h2beta.com


### PR DESCRIPTION
Gynzy is an educational platform based in the Netherlands. We’re not sure how we ended up on this list, but please consider removing us 🙏

More info: https://www.gynzy.com/en/ happy to provide additional details if needed 😇