### PR TITLE
Add easymails.cc disposable email domain

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1169,6 +1169,7 @@ ease.es
 easy-trash-mail.com
 easyhomefit.com
 easymailer.live
+easymails.cc
 easynetwork.info
 easytrashmail.com
 eatmea2z.club


### PR DESCRIPTION
You can generate a disposable email by going to https://easymails.cc/.

Screenshot below:
<img width="960" height="520" alt="A08Q4sh1yi" src="https://github.com/user-attachments/assets/15c884a9-97d6-410e-9bc3-0bf628959ed1" />

