### PR TITLE
Add new disposable email domains to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1109,7 +1109,6 @@ dndent.com
 dnses.ro
 doanart.com
 dob.jp
-docsfy.com
 dodgeit.com
 dodgemail.de
 dodgit.com


### PR DESCRIPTION
To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
------
These are part of the addresses we found to be temporary. Due to the length of the list, we need more volunteers to provide the screenshots.