### PR TITLE
Revert "Remove altmails.com"

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -363,6 +363,7 @@ alpinewe.us
 alreval.com
 altairwe.us
 altitudewe.us
+altmails.com
 altuswe.us
 aluimport.com
 ama-trade.de


### PR DESCRIPTION
Actually, they're still doing it. @nillpoe 

<img width="777" height="314" alt="Screenshot 2025-12-09 at 12 31 37 PM" src="https://github.com/user-attachments/assets/4655ff31-32eb-40e5-82ef-9845341df641" />
Reverts disposable-email-domains/disposable-email-domains#810