### PR TITLE
Add roratu.com to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3618,6 +3618,7 @@ rollindo.agency
 ronete.com
 ronnierage.net
 rootfest.net
+roratu.com
 rosebearmylove.ru
 rotaniliam.com
 rotomails.co.uk


### PR DESCRIPTION
accessed this from temp-mail.org. a well-known disposable email site.
<img width="1512" height="497" alt="Screenshot 2025-12-17 at 06 51 57" src="https://github.com/user-attachments/assets/86f8e4ac-d498-4ada-b0b6-83394d0831bd" />
