### PR TITLE
Add 'yours.tools' to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -4857,8 +4857,8 @@ yourdomain.com
 youremail.cf
 yourewronghereswhy.com
 yourlms.biz
-yourspamgoesto.space
 yours.tools
+yourspamgoesto.space
 yourtube.ml
 youxiang.dev
 yroid.com


### PR DESCRIPTION
<img width="1185" height="329" alt="image" src="https://github.com/user-attachments/assets/9c9b9377-a42f-4a84-a430-2404a4b0fe61" />
allows creation of disposable emails via https://yours.tools/tempemail.html