### PR TITLE
Add airsworld.net to the disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -302,6 +302,7 @@ ahvin.com
 ailicke.com
 air2token.com
 airmailbox.website
+airsworld.net
 aiworldx.com
 aixnv.com
 ajaxapp.net


### PR DESCRIPTION
To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.


<img width="1911" height="962" alt="image" src="https://github.com/user-attachments/assets/20c7206a-8226-43c4-b2a6-734df3c075ab" />

mail.tm website is now generating new domains which are not included in disposable list.