### PR TITLE
Add several disposable email domains to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2029,6 +2029,7 @@ httpsgreenwichmeantime.in
 huangniu8.com
 hubglee.com
 hubhost.store
+hudisk.com
 huizk.com
 hukkmu.tk
 hulapla.de


### PR DESCRIPTION
This PR adds several domains to disposable_email_blocklist.conf.
These domains are used by temp-mail.org to provide disposable email addresses.