### PR TITLE
Use mktemp so we don't write to disk

### DIFF
--- a/maintain.sh
+++ b/maintain.sh
@@ -3,9 +3,12 @@
 # Unify locale settings temporarily to make sort produce the same order
 export LC_ALL=C
 
-# Converts uppercase to lowercase, sorts, removes duplicates and removes allowlisted domains
-cat disposable_email_blocklist.conf | tr '[:upper:]' '[:lower:]' | sort -f | uniq -i  > temp.conf
-comm -23 temp.conf allowlist.conf > disposable_email_blocklist.conf
+# Create temporary file to work on
+TMPFILE=`mktemp`
 
-rm temp.conf
+# Converts uppercase to lowercase, sorts, removes duplicates and removes allowlisted domains
+cat disposable_email_blocklist.conf | tr '[:upper:]' '[:lower:]' | sort -f | uniq -i  > $TMPFILE
+comm -23 $TMPFILE allowlist.conf > disposable_email_blocklist.conf
+
+rm $TMPFILE
 echo "Done!"


### PR DESCRIPTION
This script unnecessarily writes to disk. 
Could've been a one-liner but that would sacrifice readability.
mktemp is a good compromise. Keeps script short and is pretty portable (available on GNU Core Utils, BusyBox, OpenBSD, FreeBSD)