### PR TITLE
Add mypup.nl to allow list because it't not a (disposable) email provider at all

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -125,6 +125,7 @@ mm.st
 mozmail.com
 myfastmail.com
 mymacmail.com
+mypup.nl
 naver.com
 neverbox.com
 nigge.rs

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3026,7 +3026,6 @@ myopang.com
 mypacks.net
 mypartyclip.de
 myphantomemail.com
-mypup.nl
 mysamp.de
 myspaceinc.com
 myspaceinc.net


### PR DESCRIPTION
MyPup is a parcel delivery company and does not provide disposable email addresses.

Unfortunately we're being harassed at the moment and someone put our domain name mypup.nl up for disposable e-mail domain. We're still investigating where it comes from, but it would be nice if it could be on this allow list.