### PR TITLE
remove all domains provided through the poisoned automated path

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -609,7 +609,6 @@ blackmarket.to
 bladesmail.net
 blenched.com
 blenro.com
-blinkmail.space
 blip.ch
 blip.ovh
 blnkt.net
@@ -885,7 +884,6 @@ colaname.com
 coldemail.info
 collegewh.edu.pl
 colorcastmail.com
-colurmish.com
 comfythings.com
 compareshippingrates.org
 completegolfswing.com
@@ -1146,7 +1144,6 @@ dona.one
 dona.pw
 dona.rip
 donebyngle.com
-donemail.my.id
 donemail.ru
 dongqing365.com
 dontreg.com
@@ -1211,7 +1208,6 @@ dunkos.xyz
 durandinterstellar.com
 duskmail.com
 dusrui.com
-dustbinmail.de
 dv2.host
 dvdpit.com
 dwse.edu.pl
@@ -1498,7 +1494,6 @@ fakeinformation.com
 fakemail.fr
 fakemail.io
 fakemail.net
-fakemailbox.tech
 fakemailgenerator.com
 fakemailz.com
 fallinhay.com
@@ -1534,7 +1529,6 @@ fasttoyota.com
 fastyamaha.com
 fatflap.com
 faxico.com
-faybetsy.com
 fbi.one
 fbma.tk
 fddns.ml
@@ -1552,7 +1546,6 @@ fexbox.ru
 fexpost.com
 fextemp.com
 fft.edu.do
-fiallaspares.com
 fibmail.com
 ficken.de
 fictionsite.com
@@ -1784,7 +1777,6 @@ ggmal.ml
 ggvk.ru
 ggvk.store
 gholar.com
-ghostinbox.pro
 ghosttexter.de
 giacmosuaviet.info
 giaiphapmuasam.com
@@ -1964,7 +1956,6 @@ helpjobs.ru
 heros3.com
 herp.in
 herpderp.nl
-heydamail.xyz
 hezll.com
 hh7f.com
 hhe.org.uk
@@ -2086,14 +2077,12 @@ ignoremail.com
 ihateyoualot.info
 ihazspam.ca
 iheartspam.org
-ihnpo.food
 ikbenspamvrij.nl
 ikewe.com
 ikomail.com
 ikuromi.com
 illistnoise.com
 illubd.com
-ilove4.skin
 ilovespam.com
 im5z.com
 imail.edu.vn
@@ -2294,7 +2283,6 @@ jumonji.tk
 jungkamushukum.com
 junk.to
 junk1e.com
-junk4.me
 junkmail.ga
 junkmail.gq
 just-email.com
@@ -2492,7 +2480,6 @@ ligsb.com
 likemovie.net
 lillemap.net
 lilo.me
-lilpup.shop
 lilspam.com
 lindenbaumjapan.com
 link2mail.net
@@ -2537,7 +2524,6 @@ lordsofts.com
 lortemail.dk
 losemymail.com
 love-your.mom
-love4.skin
 lovemeet.faith
 lovemeleaveme.com
 lpfmgmtltd.com
@@ -2714,9 +2700,7 @@ mailjunk.ga
 mailjunk.gq
 mailjunk.ml
 mailjunk.tk
-mailjunkie.fun
 mailmagnet.co
-mailmask.cc
 mailmate.com
 mailmaxy.one
 mailmay.org
@@ -2737,7 +2721,6 @@ mailnada.cc
 mailnada.com
 mailnator.com
 mailnesia.com
-mailnoop.store
 mailnull.com
 mailnuo.com
 mailonaut.com
@@ -2841,7 +2824,6 @@ meltp.com
 memeazon.com
 memsg.site
 mentonit.net
-meomo.store
 mepost.pw
 merepost.com
 merry.pink
@@ -2979,7 +2961,6 @@ muell.monster
 muell.xyz
 muellemail.com
 muellmail.com
-muetop.store
 mugadget.com
 munik.edu.pl
 munoubengoshi.gq
@@ -3018,12 +2999,10 @@ mymailoasis.com
 mymaily.lol
 mynes.com
 mynetstore.de
-mynoop.store
 myopang.com
 mypacks.net
 mypartyclip.de
 myphantomemail.com
-mypup.nl
 mysamp.de
 myspaceinc.com
 myspaceinc.net
@@ -3148,14 +3127,12 @@ nomail.cf
 nomail.ga
 nomail.pw
 nomail2me.com
-nomailhero.com
 nomorespamemails.com
 nonchalantresmita.biz
 nongnue.com
 nonspam.eu
 nonspammer.de
 nonze.ro
-nooploop.store
 noopmail.com
 noref.in
 noreply.fr
@@ -3521,13 +3498,10 @@ puglieisi.com
 puji.pro
 punkass.com
 punkproof.com
-pup.yachts
-pupno.xyz
 puppetmail.de
 purcell.email
 purelogistics.org
 pursip.com
-pushcom.store
 pusmail.com
 pussport.com
 put2.net
@@ -3559,7 +3533,6 @@ qtum-ico.com
 quadrafit.com
 questtechsystems.com
 quick-mail.cc
-quickdrop.site
 quickemail.info
 quickinbox.com
 quickmail.nl
@@ -3809,7 +3782,6 @@ sidement.com
 siftportal.ru
 sify.com
 signalxp.com
-sihanoma.store
 sika3.com
 sikux.com
 silenceofthespam.com
@@ -3953,7 +3925,6 @@ spamday.com
 spamdecoy.net
 spamex.com
 spamfellas.com
-spamfig.xyz
 spamfighter.cf
 spamfighter.ga
 spamfighter.gq
@@ -4103,7 +4074,6 @@ talmetry.com
 tanlanav.com
 tanukis.org
 taobudao.com
-taohucom.store
 tapchicuoihoi.com
 taphear.com
 tapi.re
@@ -4164,7 +4134,6 @@ tempemail.net
 tempemailgen.com
 tempemaill.com
 tempemailo.org
-tempflux.nl
 tempinbox.co.uk
 tempinbox.com
 tempmail.best
@@ -4390,7 +4359,6 @@ trash-me.com
 trash2009.com
 trash2010.com
 trash2011.com
-trashcan.email
 trashcanmail.com
 trashdevil.com
 trashdevil.de
@@ -4840,7 +4808,6 @@ xn--9kq967o.com
 xn--d-bga.net
 xn--yaho-sqa.com
 xojxe.com
-xopmail.fun
 xost.us
 xoxox.cc
 xperiae5.com


### PR DESCRIPTION
xref: https://github.com/disposable-email-domains/disposable-email-domains/pull/846

this likely removed more than needed, since we do not differentiate between providers in the automation, but it will be fixed during the next automation round
