### PR TITLE
Add vertexinbox.com to the disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -4647,6 +4647,7 @@ vercelli.gq
 vercelli.ml
 verdejo.com
 vermutlich.net
+vertexinbox.com
 vertexium.net
 veruvercomail.com
 veryday.ch


### PR DESCRIPTION
Taken from - https://temporarymail.com/en/

<img width="1470" height="883" alt="vertexinbox com" src="https://github.com/user-attachments/assets/7dabaf2a-99df-455f-b28c-652e511591ed" />

