### PR TITLE
chore: add imfaya.com emails to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2137,6 +2137,7 @@ imails.asso.st
 imails.info
 imailt.com
 imap.fr.nf
+imfaya.com
 img-free.com
 imgof.com
 imgv.de
@@ -5087,4 +5088,3 @@ zyns.com
 zzi.us
 zzrgg.com
 zzz.com
-imfaya.com


### PR DESCRIPTION
## Disposable Email Domain Verification

The domain **`imfaya.com`** can be generated via the disposable email service **Temp Mail**.

### Steps to Reproduce
1. Visit: https://temp-mail.org/en/
2. A temporary email address is automatically generated on page load.
3. The generated address may use the `imfaya.com` domain.

### Evidence
The screenshot below shows an email address generated by Temp Mail using the `@imfaya.com` domain, confirming that it is actively used by a disposable email provider.

![Temp Mail `imfaya.com` domain evidence](https://github.com/user-attachments/assets/4843741f-e9bd-46a9-8cef-6bf2f72906c1)

### Conclusion
Since `imfaya.com` is verifiably used by a disposable email service, it should be included in the blocked disposable email domain list.
