### PR TITLE
Add awesomesaucemail.org to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -507,6 +507,7 @@ awa.pics
 awatum.de
 awdrt.org
 awesome47.com
+awesomesaucemail.org
 awgarstone.com
 awiki.org
 awsoo.com


### PR DESCRIPTION
To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.

https://tempmail.lol/en/

This website rotates between the following domains, 2 of which are already on the list:
chessgameland.com
awesomesaucemail.org
chessgamingworld.com

They also generate emails with random subdomains on these 3 parent domains. Should we add a note in the README about matching only parent domains if that would help others avoid skipping these domains?