### PR TITLE
Add relay.mozmail.com to whitelist

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -123,6 +123,7 @@ memeware.net
 ml1.net
 mm.st
 mozmail.com
+relay.mozmail.com
 myfastmail.com
 mymacmail.com
 naver.com


### PR DESCRIPTION
relay.mozmail.com is used by Firefox Relay for authenticated email alias forwarding.

Since mozmail.com is already whitelisted and Firefox Relay does not offer disposable or publicly accessible inboxes, this subdomain should be treated the same.

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
