### PR TITLE
Update disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -5127,6 +5127,7 @@ zvvzuv.com
 zx81.ovh
 zxcv.com
 zxcvbnm.com
+coffeeity.com
 zymuying.com
 zyns.com
 zzi.us


### PR DESCRIPTION
adds to blocklist coffeeity.com

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
