### PR TITLE
Add 70 disposable/temporary email domains identified from production abuse patterns

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -54,6 +54,7 @@
 10minutmail.pl
 10x9.com
 11163.com
+1200b.com
 123-m.com
 123clone.com
 123mails.org
@@ -117,6 +118,7 @@
 2chmail.net
 2ether.net
 2fdgdfgdfgdf.tk
+2insp.com
 2odem.com
 2prong.com
 2wc.info
@@ -319,6 +321,7 @@ air2token.com
 airmailbox.website
 airsworld.net
 aiworldx.com
+aixind.com
 aixnv.com
 ajaxapp.net
 akapost.com
@@ -525,6 +528,7 @@ azame.pw
 azazazatashkent.tk
 azcomputerworks.com
 azeqsd.fr.nf
+azeriom.com
 azmeil.tk
 azulejoslowcost.es
 azuretechtalk.net
@@ -854,6 +858,7 @@ chosenx.com
 chuan.info
 chumpstakingdumps.com
 cigar-auctions.com
+cimario.com
 citmo.net
 civikli.com
 civx.org
@@ -908,6 +913,7 @@ codeandscotch.com
 codeguard.net
 coderdir.com
 codestar.site
+codgal.com
 codivide.com
 coffeeazzan.com
 coffeejadore.com
@@ -947,6 +953,7 @@ coreclip.com
 corhash.net
 cosmorph.com
 cosoinan.com
+coswz.com
 cotasen.com
 cotigz.com
 courriel.fr.nf
@@ -1073,18 +1080,23 @@ delayload.net
 delikkt.de
 delivrmail.com
 delorex.com
+deltabox.cfd
 deluxmail.com
 demen.ml
 dengekibunko.ga
 dengekibunko.gq
 dengekibunko.ml
+denipl.com
+denipl.net
 deornaumail.com
+deposin.com
 der-kombi.de
 derkombi.de
 derluxuswagen.de
 desertsundesigns.com
 desfrenes.fr.nf
 deshnetarchadacalculator.one
+desiys.com
 desoz.com
 despam.it
 despammed.com
@@ -1175,6 +1187,7 @@ dodsi.com
 dogclothing.org
 doiea.com
 doj.one
+dollicons.com
 dolphinnet.net
 domforfb1.tk
 domforfb18.tk
@@ -1218,6 +1231,7 @@ dp76.com
 dpmurt.my
 dpptd.com
 dr69.site
+dramamixio.icu
 drdrb.com
 drdrb.net
 dreamclarify.org
@@ -1497,6 +1511,7 @@ evanfox.info
 eveav.com
 evilcomputer.com
 evnft.com
+evoiceeeeee.world
 evopo.com
 evusd.com
 evvgo.com
@@ -1644,6 +1659,7 @@ fkainc.com
 flaimenet.ir
 fleckens.hu
 flemail.ru
+flemist.com
 flexvio.com
 fliegender.fish
 flobo.fr.nf
@@ -1781,6 +1797,7 @@ gally.jp
 gamail.top
 gamebcs.com
 gamegregious.com
+gamening.com
 gamepec.com
 gamgling.com
 garasikita.pw
@@ -1813,6 +1830,7 @@ genderfuck.net
 generator.email
 genzmaile.com
 genzotp.com
+geriloios.com
 geronra.com
 geschent.biz
 get-mail.cf
@@ -1848,6 +1866,7 @@ ggmal.ml
 ggvk.ru
 ggvk.store
 gholar.com
+ghostmail.live
 ghosttexter.de
 giacmosuaviet.info
 giaiphapmuasam.com
@@ -1881,6 +1900,7 @@ globalbizflow.com
 globaltouron.com
 glubex.com
 glucosegrin.com
+gmail10p.com
 gmail2.gq
 gmailot.com
 gmatch.org
@@ -1974,6 +1994,7 @@ gukox.org
 gustr.com
 guysmail.com
 gxemail.men
+gxuzi.com
 gyan-netra.com
 gyknife.com
 gynzi.co.uk
@@ -2023,6 +2044,7 @@ heathenhero.com
 hecat.es
 heheee.com
 heisei.be
+helesco.com
 hellodream.mobi
 helloricky.com
 helpinghandtaxcenter.org
@@ -2064,12 +2086,14 @@ hola.org
 holio.day
 holl.ga
 homecut.pro
+homuno.com
 honesthirianinda.net
 honeys.be
 honor-8.com
 hook2ad.com
 hooooooo.store
 hopemail.biz
+hopesx.com
 horizonspost.com
 hornyalwary.top
 host1s.com
@@ -2132,6 +2156,7 @@ ichigo.me
 icidroit.info
 iconmal.com
 icousd.com
+icubik.com
 icx.in
 icx.ro
 icznn.com
@@ -2293,6 +2318,7 @@ it7.ovh
 italy-mail.com
 itaolo.com
 itcompu.com
+itezer.com
 itfast.net
 itsbds.com
 itsedit.click
@@ -2366,6 +2392,7 @@ jourrapide.com
 jp-ml.com
 jpco.org
 jsrsolutions.com
+juhxs.com
 jumonji.tk
 jungkamushukum.com
 junk.to
@@ -2647,6 +2674,7 @@ lyfestylecreditsolutions.com
 lyft.live
 lynex.sbs
 lynwise.shop
+lyoris.cfd
 lyricspad.net
 lzoaq.com
 m21.cc
@@ -2840,6 +2868,7 @@ mailpro.lat
 mailpro.live
 mailproxsy.com
 mailpull.com
+mailpwr.com
 mailquack.com
 mailrock.biz
 mailsac.com
@@ -2891,6 +2920,7 @@ mandraghen.cf
 manifestgenerator.com
 mannawo.com
 mansiondev.com
+manupay.com
 mark-compressoren.ru
 marketlink.info
 markmurfin.com
@@ -2903,6 +2933,8 @@ matchpol.net
 matmayer.com
 matra.site
 max-mail.org
+maximail.fyi
+maximail.vip
 maxresistance.com
 maxturns.com
 mbox.re
@@ -2975,6 +3007,7 @@ mikrotikvietnam.com
 mikrotikvn.com
 mikrotikx.com
 miloras.fr.nf
+mimimail.me
 minefieldmail.com
 minimail.gq
 ministry-of-silly-walks.de
@@ -3085,11 +3118,13 @@ muellemail.com
 muellmail.com
 muetop.store
 mugadget.com
+muhaos.com
 munik.edu.pl
 munoubengoshi.gq
 muonwhila.com
 musiccode.me
 mutant.me
+muzibt.com
 mvpmedix.com
 mvrht.com
 mvrht.net
@@ -3203,6 +3238,7 @@ newbpotato.tk
 newfilm24.ru
 newideasfornewpeople.info
 newmail.top
+newtrea.com
 next.ovh
 nextmail.info
 nextstopvalhalla.com
@@ -3260,6 +3296,7 @@ nomail2me.com
 nomes.fr.nf
 nomorespamemails.com
 nonchalantresmita.biz
+nondon.store
 nongnue.com
 nonspam.eu
 nonspammer.de
@@ -3331,6 +3368,7 @@ odaymail.com
 odeask.com
 odem.com
 odnorazovoe.ru
+oemails.com
 oepia.com
 oerpub.org
 ofanda.com
@@ -3344,6 +3382,7 @@ oida.icu
 oing.cf
 okcdeals.com
 okclprojects.com
+okexbit.com
 okhko.com
 okiae.com
 okinawa.li
@@ -3459,6 +3498,7 @@ pastryofistanbul.com
 patity.com
 patonce.com
 pavilionx2.com
+paviri.com
 paxlys.com
 payperex2.com
 payspun.com
@@ -3485,6 +3525,7 @@ phanmembanhang24h.com
 philipdowney.com
 phimib.com
 phone-elkey.ru
+phongpon.click
 photo-impact.eu
 photobrex.com
 photomark.net
@@ -3494,6 +3535,7 @@ physicaladithama.io
 pi.vu
 piaa.me
 picdirect.net
+pidge.cfd
 pig.pp.ua
 pigeonprotocol.com
 pii.at
@@ -3562,6 +3604,7 @@ postacin.com
 postbx.ru
 postbx.store
 postonline.me
+poststream.cfd
 poubelle-du.net
 poubelle.fr.nf
 poutineyourface.com
@@ -3707,6 +3750,7 @@ ramenmail.de
 ramin200.site
 ramizan.com
 rancidhome.net
+rancord.com
 randol.infos.st
 randomail.io
 randomail.net
@@ -3744,6 +3788,7 @@ reimondo.com
 rejectmail.com
 rejo.technology
 rekaer.com
+relayix.cfd
 reliable-mail.com
 remail.cf
 remail.ga
@@ -3816,8 +3861,10 @@ ruru.be
 rustydoor.com
 rustyload.com
 ruu.kr
+ruutukf.com
 rvb.ro
 rwstatus.com
+rybang.com
 rygel.infos.st
 ryteto.me
 ryyr.ru
@@ -3891,6 +3938,7 @@ sendos.infos.st
 sendspamhere.com
 senseless-entertainment.com
 seosnaps.com
+sepole.com
 seqerc.com
 server.ms
 servicee.es
@@ -4052,6 +4100,7 @@ soon.it
 soscandia.org
 soyboy.observer
 sozenit.com
+spaakir.com
 spacebazzar.ru
 spacehotline.com
 spam-be-gone.com
@@ -4180,6 +4229,7 @@ storj99.com
 storj99.top
 streetwisemail.com
 stromox.com
+sttaartools.shop
 stuckmail.com
 stuffmail.de
 stufmail.com
@@ -4188,11 +4238,14 @@ stylist-volos.ru
 submic.com
 suburbanthug.com
 suckmyd.com
+sudarin.online
 sudern.de
 sueshaw.com
 suexamplesb.com
 suftwari.com
+suiemail.com
 suioe.com
+sulfil.com
 super-auswahl.de
 super.lgbt
 superblohey.com
@@ -4232,6 +4285,7 @@ tagara.infos.st
 taglead.com
 tagmymedia.com
 tagyourself.com
+taimanin.com
 taimb.com
 talemarketing.com
 talkinator.com
@@ -4246,6 +4300,7 @@ taphear.com
 tapi.re
 tartinemoi.com
 tarzanmail.cf
+tasiw.com
 tastmemail.com
 tastrg.com
 tatadidi.com
@@ -4513,6 +4568,7 @@ totalvista.com
 totesmail.com
 totoan.info
 totococo.fr.nf
+toukib.com
 tourcc.com
 tozya.com
 tp-qa-mail.com
@@ -4595,6 +4651,7 @@ ttszuo.xyz
 tualias.com
 tuamaeaquelaursa.com
 tubeemail.com
+tuiaa.com
 tumroc.net
 tuofs.com
 tupmail.com
@@ -4634,10 +4691,12 @@ uhhu.ru
 uiemail.com
 uiu.us
 ujijima1129.gq
+ujoice.com
 uk.to
 ukm.ovh
 ultra.fyi
 ultrada.ru
+ultraveoworkin.store
 uma3.be
 umail.net
 umil.net
@@ -4698,6 +4757,7 @@ valhalladev.com
 vankin.de
 vasteron.com
 vaupk.org
+vbbest.com
 vbv.cards
 vcois.com
 vctel.com
@@ -4733,6 +4793,7 @@ vesa.pw
 vetra.cyou
 vevs.de
 vexi.my
+vexisync.cfd
 via.tokyo.jp
 vibzi.net
 vickaentb.tk
@@ -4791,6 +4852,7 @@ vkrr.ru
 vkrr.store
 vlemi.com
 vlrregulatory.com
+vluwork.com
 vmailing.info
 vmani.com
 vmpanda.com
@@ -4899,9 +4961,11 @@ wemel.top
 wenkuu.com
 wentcity.com
 wep.email
+werucbai.com
 wetrainbayarea.com
 wetrainbayarea.org
 wfgdfhj.tk
+wfsocks.com
 wg0.com
 wh4f.org
 whaaaaaaaaaat.com
@@ -4982,6 +5046,7 @@ x24.com
 xagloo.co
 xagloo.com
 xbaby69.top
+xbefr.com
 xcode.ro
 xcodes.net
 xcompress.com
@@ -4996,6 +5061,7 @@ xepa.ru
 xfavaj.com
 xidealx.com
 ximenor.site
+xitro.cfd
 xjoi.com
 xkx.me
 xkxkud.com
@@ -5040,6 +5106,7 @@ yannmail.win
 yapped.net
 yaqp.com
 yarnpedia.ga
+yatomail.com
 ycare.de
 ycn.ro
 ye.vc
@@ -5091,6 +5158,8 @@ ytpayy.com
 yugasandrika.com
 yui.it
 yuki.ren
+yuliar.com
+yumobiz.com
 yun.pics
 yuoia.com
 yuurok.com
@@ -5164,6 +5233,7 @@ zvvzuv.com
 zx81.ovh
 zxcv.com
 zxcvbnm.com
+zxmicro.com
 zymuying.com
 zyns.com
 zzi.us


### PR DESCRIPTION
These domains were identified through analysis of signup patterns on a production SaaS platform over the past 2 weeks. All domains showed bulk registration patterns (8-50 signups each) with nonsensical domain names, characteristic of disposable email services.

Includes:
- Bulk abuse domains (.com): cimario, codgal, aixind, azeriom, etc.
- .cfd TLD domains: deltabox, lyoris, pidge, poststream, relayix, vexisync, xitro
- Various TLD domains: .icu, .world, .live, .shop, .online, .store, .click, .fyi, .vip
- Fake email service domains: gmail10p, mailpwr, oemails, suiemail, mimimail.me, etc.
