### PR TITLE
add more temp-mail.org domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -277,6 +277,7 @@ adventwe.us
 advisorwe.us
 advitise.com
 advocatewe.us
+advarm.com
 adwaterandstir.com
 aegde.com
 aegia.net
@@ -336,6 +337,7 @@ aleh.de
 alfaceti.com
 aliaswe.us
 aliban.org
+alibto.com
 alienware13.com
 aligamel.com
 aligroup.uk
@@ -407,6 +409,7 @@ amex409.monster
 amicuswe.us
 amilegit.com
 aminating.com
+amiralty.com
 amiri.net
 amiriindustries.com
 amplewe.us
@@ -626,6 +629,7 @@ biojuris.com
 bione.co
 bipochub.com
 bitmens.com
+bitonc.com
 bitwhites.top
 bitymails.us
 biz.st


### PR DESCRIPTION
* add more temp-mail.org domains detected after 2026-02-21

See e.g. https://verifymail.io/domain/tempmail.co

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
