### PR TITLE
Add free-temp-mail.eu.org domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1769,7 +1769,7 @@ fxnxs.com
 fxtubes.com
 fxzig.com
 fyii.de
-fynix.sb
+fynix.sbs
 g14l71lb.com
 g1xmail.top
 g2xmail.top


### PR DESCRIPTION
Domains that they use
free-temp-mail.eu.org
sam1.eu.org
temporaryemail.dpdns.org
![Screenshot_20260226_075106_Chrome (1)](https://github.com/user-attachments/assets/118aa754-f2a5-4ef8-8513-6abe60652607)
