### PR TITLE
Add two temp-mail.org disposable domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1178,6 +1178,7 @@ dodsi.com
 dogclothing.org
 doiea.com
 doj.one
+dolofan.com
 dolphinnet.net
 domforfb1.tk
 domforfb18.tk
@@ -2401,6 +2402,7 @@ kamen-market.ru
 kamete.org
 kamsg.com
 kanonmail.com
+kaoing.com
 kaovo.com
 kappala.info
 kara-turk.net


### PR DESCRIPTION
This PR adds two disposable email domains originating from temp-mail.org:

- dolofan.com
- kaoing.com


These domains were observed in registration attempts on a production system using temp-mail.org addresses. As requested, screenshots demonstrating these domains in temp-mail.org are provided below for verification.

<img width="1353" height="610" alt="dolofan com" src="https://github.com/user-attachments/assets/756937d3-a032-4e9a-8ac5-3d7577dd9cce" />

<img width="1361" height="634" alt="kaoing com" src="https://github.com/user-attachments/assets/96c8e3be-b994-4618-84f2-2d8e33cdfb6c" />
