### PR TITLE
Add two temp-mail.org disposable domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3425,6 +3425,7 @@ orsbap.com
 ortogenmail.com
 oshietechan.link
 oskarstalbergcitygenerator.com
+ostahie.com
 ostinmail.com
 osxofulk.com
 otherinbox.com
@@ -3473,6 +3474,7 @@ pavilionx2.com
 paxlys.com
 payperex2.com
 payspun.com
+pazuric.com
 pdf-cutter.com
 pe.hu
 peakinbox.net


### PR DESCRIPTION
This PR adds two disposable email domains originating from temp-mail.org:

- ostahie.com,
- pazuric.com


These domains were observed in registration attempts on a production system using temp-mail.org addresses. As requested, screenshots demonstrating these domains in temp-mail.org are provided below for verification.


<img width="1133" height="567" alt="ostahie com" src="https://github.com/user-attachments/assets/f7fa513c-e317-459c-8ee1-adf231d27236" />
<img width="1130" height="570" alt="pazuric com" src="https://github.com/user-attachments/assets/201261ee-c8c0-40de-9234-201745e9b066" />

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
