### PR TITLE
Add studyhub.edu.pl domain from Mailwave.dev website

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -4322,11 +4322,11 @@ storj99.top
 streetwisemail.com
 stromox.com
 stuckmail.com
+studyhub.edu.pl
 stuffmail.de
 stufmail.com
 stumpfwerk.com
 stylist-volos.ru
-studyhub.edu.pl
 submic.com
 suburbanthug.com
 suckmyd.com


### PR DESCRIPTION
<img width="1123" height="524" alt="Screenshot 2026-03-17 at 14 57 13" src="https://github.com/user-attachments/assets/e6ea450c-0905-4cf6-bb73-7b54de2a57a1" />
 
 The disposable domain 'studyhub.edu.pl' is from the website - https://mailwave.dev/
