### PR TITLE
Add seven new disposable email domains.

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2366,6 +2366,7 @@ irssi.tv
 is.af
 isdaq.com
 isep.fr.nf
+isfew.com
 ishop2k.com
 ismartsense.online
 isosq.com
@@ -2744,6 +2745,7 @@ lunor.cfd
 lushosa.com
 lutech.uk
 luv2.us
+lxbeta.com
 lydir.com
 lyfestylecreditsolutions.com
 lyft.live
@@ -3482,6 +3484,7 @@ omarnasrrr.com
 omfg.run
 omnievents.org
 omtecha.com
+onbap.com
 one-mail.top
 one-ml.com
 one-sec-mail.site
@@ -3586,8 +3589,10 @@ patity.com
 patonce.com
 pavilionx2.com
 paxlys.com
+paylaar.com
 payperex2.com
 payspun.com
+pazard.com
 pazuric.com
 pckage.com
 pdf-cutter.com
@@ -3820,6 +3825,7 @@ quillet.eu
 quinz.me
 quipas.com
 ququb.com
+qvmao.com
 qvy.me
 qwickmail.com
 qzueos.com
@@ -4157,6 +4163,7 @@ soc123.net
 social-mailer.tk
 socialfurry.org
 sociallymediocre.com
+soco7.com
 socoori.com
 sofia.re
 sofimail.com


### PR DESCRIPTION
This PR adds seven disposable email domains originating from temp-mail.org:

- isfew.com
- lxbeta.com
- onbap.com
- paylaar.com
- pazard.com
- qvmao.com
- soco7.com

These domains were observed in registration attempts on a production system using temp-mail.org addresse. As requested, screenshots demonstrating these domains in those services are provided below for verification.


<img width="1245" height="598" alt="isfew com" src="https://github.com/user-attachments/assets/aab2f86c-2dfe-4f95-a24d-5925fc89bf21" />
<img width="1238" height="619" alt="lxbeta com" src="https://github.com/user-attachments/assets/f446eac2-b899-4401-9ed7-6ea8a508228a" />
<img width="1318" height="598" alt="onbap com" src="https://github.com/user-attachments/assets/92c22165-00df-4c8f-acb7-70d582caea92" />
<img width="1268" height="606" alt="paylaar com" src="https://github.com/user-attachments/assets/5e531e40-1938-4895-be75-d78edc4e932c" />
<img width="1321" height="603" alt="pazard com" src="https://github.com/user-attachments/assets/8b4cfd5f-6ee0-472d-8021-3dc105021262" />
<img width="1279" height="600" alt="qvmao com" src="https://github.com/user-attachments/assets/7d433d46-31bb-42c7-9c1c-1066ad58cc57" />
<img width="1142" height="554" alt="soco7 com" src="https://github.com/user-attachments/assets/df72e402-ec57-4310-b0ea-0930796a04a5" />



To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
