### PR TITLE
Move atomicmail.io from disposablelist to allowlist

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -17,6 +17,7 @@ airsi.de
 allmail.net
 antichef.com
 antichef.net
+atomicmail.io
 belt.io
 bestmail.us
 bluewin.ch

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -508,7 +508,6 @@ asurad.com
 at.hm
 at0mik.org
 atnextmail.com
-atomicmail.io
 attnetwork.com
 au1688x.us
 aubady.com


### PR DESCRIPTION
Hi! I am requesting the removal of atomicmail.io from the blocklist and adding it to the allowlist. 

Our service is a full-scale encrypted email provider with permanent accounts with strong encryption and privacy-first architecture, GDPR-compliant account deletion procedures and Anti-abuse systems in place, including spam protection and account monitoring.
We have also been reviewed and classified as 'Low-Risk' by enterprise security vendors like Palo Alto Networks (I will attach a screenshot).
<img width="1710" height="1107" alt="2026-03-20_15-54-19" src="https://github.com/user-attachments/assets/8f31099d-315c-40cc-81b7-1e7b17c8a98f" />
