### PR TITLE
Add fakeout as alternative NPM package

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,7 @@ function isPermanentEmail(email) {
 }
 ```
 
-Alternatively check out NPM package https://github.com/mziyut/disposable-email-domains-js.
-
-Also check out [fakeout](https://www.npmjs.com/package/fakeout) — a zero-dependency package with an auto-updating blocklist that syncs daily via CI/CD, publishing new patch versions automatically. It provides `isDisposableEmail()`, `isDisposableDomain()`, and `getDisposableDomains()` functions with full TypeScript support.
+Alternatively check out NPM packages https://github.com/mziyut/disposable-email-domains-js (updated weekly) and https://www.npmjs.com/package/fakeout (updated daily).
 
 ### C#
 ```C#


### PR DESCRIPTION
## Summary

Hey! I noticed the existing NPM package listed here (`disposable-email-domains-js`) can sometimes take weeks to catch up with changes made to this repo. Since this blocklist gets updated frequently via git, there's a gap between when a domain is added here and when it's available to Node.js users pulling from npm.

[fakeout](https://www.npmjs.com/package/fakeout) solves this by syncing directly with this repo daily via CI/CD and auto-publishing patch releases — so Node.js consumers stay up to date without manual intervention. It also:

- Has zero dependencies (just a `Set` lookup)
- Ships with full TypeScript support
- Provides convenient helpers: `isDisposableEmail()`, `isDisposableDomain()`, `getDisposableDomains()`

Given how actively this repo is maintained, having an npm package that actually keeps pace with it feels like a good addition. Not replacing the existing alternative — just offering another option that prioritizes staying in sync.