### PR TITLE
This PR adds seven disposable email domains originating from temp-mail.org to the blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1555,11 +1555,13 @@ evusd.com
 evvgo.com
 evyush.com
 ewebrus.com
+exahut.com
 examstudy.xyz
 exbts.com
 exclussi.com
 exdonuts.com
 exelica.com
+exespay.com
 exile.my.id
 existiert.net
 exitbit.com
@@ -1583,6 +1585,7 @@ ezstest.com
 ezua.com
 ezztt.com
 f4k.es
+fabaos.com
 facebook-email.cf
 facebook-email.ga
 facebook-email.ml
@@ -1804,6 +1807,7 @@ fukurou.ch
 fullangle.org
 fulvie.com
 fumemail.com
+fun4k.com
 fun64.com
 fundapk.com
 fundproceed.com
@@ -2453,6 +2457,7 @@ josse.ltd
 jourrapide.com
 jp-ml.com
 jpco.org
+jsncos.com
 jsrsolutions.com
 jualfb.co
 jumonji.tk
@@ -3197,6 +3202,7 @@ muellemail.com
 muellmail.com
 muetop.store
 mugadget.com
+muncloud.com
 munik.edu.pl
 munoubengoshi.gq
 muonwhila.com
@@ -4148,6 +4154,7 @@ smellfear.com
 smellrear.com
 smellypotato.tk
 smeux.com
+smkanba.com
 smncloud.com
 smtp99.com
 smwg.info


### PR DESCRIPTION
This PR adds seven disposable email domains originating from temp-mail.org to the blocklist:

- exahut.com
- exespay.com
- fabaos.com
- fun4k.com
- jsncos.com
- muncloud.com
- smkanba.com

These domains were observed in registration attempts on a production system using temp-mail.org addresses. As requested, screenshots demonstrating these domains in those services are provided below for verification.
<img width="1322" height="612" alt="exahut com" src="https://github.com/user-attachments/assets/c3501f0e-381e-4192-a9d1-a65cf03cb644" />
<img width="1357" height="628" alt="exespay com" src="https://github.com/user-attachments/assets/1b3aa6f6-5c77-43f2-96b3-9a54c8f43869" />
<img width="1320" height="592" alt="fabaos com" src="https://github.com/user-attachments/assets/5d07caf6-55b1-451a-9125-ffcb6ec6b7bc" />
<img width="1359" height="603" alt="fun4k com" src="https://github.com/user-attachments/assets/feb17bb6-eb74-46fd-b731-cae35a1397f0" />
<img width="1351" height="595" alt="jsncos com" src="https://github.com/user-attachments/assets/d72f55f1-d2a9-4f5f-9652-16e70d588a67" />
<img width="1057" height="551" alt="muncloud com" src="https://github.com/user-attachments/assets/7f9a6254-8def-462a-9664-2a443e7685a9" />
<img width="1351" height="624" alt="smkanba com" src="https://github.com/user-attachments/assets/65227c17-65e9-4482-9819-554bebb47223" />






To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
