### PR TITLE
Add 'noexpire.top' to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3377,6 +3377,7 @@ nocp.ru
 nocp.store
 nodejs.uk
 nodezine.com
+noexpire.top
 nogmailspam.info
 noicd.com
 nokdot.com


### PR DESCRIPTION
This domain https://instant-email.org/ has been active for quite a long time. I’m surprised it hasn’t been added to the blocklist yet, especially considering how widely it’s being used nowadays.


