### PR TITLE
Add 'emailboxer.one' to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1406,6 +1406,7 @@ emailate.com
 emailawb.pro
 emailbbox.pro
 emailbin.net
+emailboxer.one
 emailcbox.pro
 emailcoffeehouse.com
 emailcu.icu


### PR DESCRIPTION
This domain https://instant-email.org/ has been active for quite a long time. I’m surprised it hasn’t been added to the blocklist yet, especially considering how widely it’s being used nowadays.


<img width="564" height="351" alt="image" src="https://github.com/user-attachments/assets/3fe319fd-03ba-4357-9d54-b0b170167825" />
<img width="1203" height="638" alt="image" src="https://github.com/user-attachments/assets/dbe10991-1743-4318-a57f-abc746ff9c1c" />
