### PR TITLE
Add nazisat.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3299,6 +3299,7 @@ nawmin.info
 naxx.dev
 naylonksosmed.com
 naymedia.com
+nazisat.com
 nbmbb.com
 nbzmr.com
 ncien.com


### PR DESCRIPTION
Adding `nazisat.com` to the blocklist.

**Source:** [temp-mail.org](https://temp-mail.org) — `nazisat.com` is one of the disposable domains offered by temp-mail.org.

Third-party verification:
- https://verifymail.io/domain/nazisat.com — flagged as disposable, attributed to temp-mail.org
- https://www.usercheck.com/domain/quick-mail.cc — lists nazisat.com among recent temp-mail.org domains

Ran `maintain.sh` after adding the domain.