### PR TITLE
Add dollicons.com and sharebot.net

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1219,6 +1219,7 @@ dogclothing.org
 doiea.com
 doj.one
 dolofan.com
+dollicons.com
 dolphinnet.net
 domforfb1.tk
 domforfb18.tk
@@ -4063,6 +4064,7 @@ sgatra.com
 sgm.ovh
 shadap.org
 shalar.net
+sharebot.net
 sharedmailbox.org
 sharkfaces.com
 sharklasers.com


### PR DESCRIPTION
## Summary

- Add **dollicons.com** and **sharebot.net** to the disposable email blocklist
- Both domains are used for mass-created disposable accounts on e-commerce platforms
- Identified through fraud analysis on 692 flagged accounts: 100% one-shot promo abuse, auto-generated email local parts (e.g. `332autonomous@dollicons.com`, `yellowannissa@sharebot.net`)

## Evidence

| Domain | Fraudulent accounts | Pattern |
|---|---|---|
| dollicons.com | 119 | 100% one-shot, 100% promo, auto-generated local parts |
| sharebot.net | 77 | 100% one-shot, 100% promo, all linked to a single referrer |

Note: `airsworld.net` and `virgilian.com` (same fraud ring) are already in the blocklist.