### PR TITLE
Add cloaked.com, cloaked.dev, and cloaked.id to allowlist

### DIFF
--- a/allowlist.conf
+++ b/allowlist.conf
@@ -23,6 +23,8 @@ bestmail.us
 bluewin.ch
 c2.hu
 cluemail.com
+cloaked.com
+cloaked.dev
 cloaked.id
 cocaine.ninja
 cock.email

--- a/allowlist.conf
+++ b/allowlist.conf
@@ -23,6 +23,7 @@ bestmail.us
 bluewin.ch
 c2.hu
 cluemail.com
+cloaked.id
 cocaine.ninja
 cock.email
 cock.li


### PR DESCRIPTION
## Summary

Add `cloaked.com`, `cloaked.dev`, and `cloaked.id` to the allowlist. These are corporate email domains for Cloaked, Inc. — not disposable or relay email services.

- MX records point to Google Workspace (aspmx.l.google.com)
- Domains are 5+ years old
- Kickbox, DeBounce, Validator.pizza, and Mailcheck.ai all classify them as NOT disposable
- Not present in this repo's blocklist, but adding to the allowlist provides explicit protection against future false additions

Cloaked operates separate relay domains for its email forwarding product — those are distinct from the corporate domains.

**Source:** Cloaked founder