### PR TITLE
Add parsitv.com to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3597,6 +3597,7 @@ papierkorb.me
 paplease.com
 para2019.ru
 parlimentpetitioner.tk
+parsitv.com
 pastebitch.com
 pastryofistanbul.com
 patity.com


### PR DESCRIPTION
This domain can be generated on temp-mail
<img width="1890" height="579" alt="image" src="https://github.com/user-attachments/assets/8354cd3f-45de-4bdd-b53b-a38ccf5d57ad" />

