### PR TITLE
Add jmailservice.com to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2445,6 +2445,7 @@ jkotypc.com
 jmail.fr.nf
 jmail.ovh
 jmail.ro
+jmailservice.com
 jnxjn.com
 jobbikszimpatizans.hu
 jobbrett.com


### PR DESCRIPTION
## Summary
- Add `jmailservice.com` to the disposable email domain blocklist
- Domain inserted in alphabetical order and processed with `maintain.sh`

## Test plan
- [x] Verified domain did not previously exist in blocklist
- [x] Confirmed alphabetical ordering is maintained
- [x] Ran `maintain.sh` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)