### PR TITLE
Add jmailservice.com to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2445,6 +2445,7 @@ jkotypc.com
 jmail.fr.nf
 jmail.ovh
 jmail.ro
+jmailservice.com
 jnxjn.com
 jobbikszimpatizans.hu
 jobbrett.com


### PR DESCRIPTION
## Summary
Add `jmailservice.com` to the disposable email domain blocklist.

## Reason
We are experiencing **contact-form spam attacks** using disposable email addresses from `jmailservice.com`. Blocking this domain will help prevent abuse originating from this service.

## Changes
- Added `jmailservice.com` to `disposable_email_blocklist.conf` in alphabetical order
- Ran `maintain.sh` to normalize the file