### PR TITLE
Add disposable email domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -669,6 +669,7 @@ blondmail.com
 bltiwd.com
 bluedumpling.info
 bluewerks.com
+bmoar.com
 bnote.com
 boatmail.us
 bobgf.ru
@@ -1313,6 +1314,7 @@ dusrui.com
 dv2.host
 dvdpit.com
 dwse.edu.pl
+dwseal.com
 dyceroprojects.com
 dygovil.com
 dz17.net
@@ -1425,6 +1427,7 @@ emailfreedom.ml
 emailgen.uk
 emailgenerator.de
 emailgo.de
+emailhook.site
 emailias.com
 emailigo.de
 emailinfive.com
@@ -1509,6 +1512,7 @@ ep77.com
 epb.ro
 epbox.ru
 epbox.store
+epetsoft.com
 ephemail.net
 ephemeral.email
 eposta.buzz
@@ -1697,6 +1701,7 @@ finews.biz
 fingso.com
 fir.hk
 fira.my
+firemail.com.br
 firemailbox.club
 firstlawyer.org
 fitnesrezink.ru
@@ -4046,6 +4051,7 @@ send22u.info
 send4.uk
 sendapp.uk
 sendfree.org
+sendgrid.ovh
 sendingspecialflyers.com
 sendnow.win
 sendos.fr.nf
@@ -4345,6 +4351,7 @@ storegmail.net
 storiqax.top
 storj99.com
 storj99.top
+strayhood.org
 streetwisemail.com
 stromox.com
 stuckmail.com
@@ -4505,6 +4512,7 @@ tempmailfree.net
 tempmailo.com
 tempmailr.com
 tempmails.net
+tempmailto.com
 tempmailyo.org
 tempomail.fr
 tempomail.org
@@ -4844,6 +4852,7 @@ upozowac.info
 upphim.net
 upsnab.net
 urfunktion.se
+urgentmail.ovh
 urhen.com
 uroid.com
 us.af


### PR DESCRIPTION
I ran through the logins on my service and found 53 domains that I am very confident are spam. This repository has a high standard to trace the domain to a public page. These are what I had the time to track down.

<img width="1230" height="646" alt="Screenshot From 2026-04-15 14-55-23" src="https://github.com/user-attachments/assets/f9a5979d-9927-4556-be51-be0148388e46" />

<img width="1230" height="646" alt="Screenshot From 2026-04-15 14-54-52" src="https://github.com/user-attachments/assets/2903c383-ad21-4c29-938b-9ba555f9b61f" />

<img width="1566" height="892" alt="Screenshot From 2026-04-15 14-48-46" src="https://github.com/user-attachments/assets/d0b96549-f02d-420e-a2b2-523c67edffac" />

<img width="1566" height="892" alt="Screenshot From 2026-04-15 14-48-06" src="https://github.com/user-attachments/assets/b4deffb4-e530-4c2c-9495-c821c6aeeb71" />

<img width="1566" height="836" alt="Screenshot From 2026-04-15 14-47-28" src="https://github.com/user-attachments/assets/090ded97-8c76-4928-a1fe-f8a2638cb5fa" />

<img width="1027" height="1304" alt="Screenshot From 2026-04-15 14-39-45" src="https://github.com/user-attachments/assets/a9302a3e-a4c7-4d74-aea7-3aa53b5f76cb" />
