### PR TITLE
Add ruutukf.com to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -3998,6 +3998,7 @@ ruru.be
 rustydoor.com
 rustyload.com
 ruu.kr
+ruutukf.com
 rvb.ro
 rwstatus.com
 rygel.infos.st


### PR DESCRIPTION
Source:
https://verifymail.io/domain/ruutukf.com
