### PR TITLE
Add verified temporary, burner, and spam email domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2346,6 +2346,7 @@ inoutmail.eu
 inoutmail.info
 inoutmail.net
 inpwa.com
+inreur.com
 insanony.art
 insanony.one
 insanony.store
@@ -3128,6 +3129,7 @@ minefieldmail.com
 minhquang2000.com
 minimail.gq
 ministry-of-silly-walks.de
+minitts.net
 minsmail.com
 mintemail.com
 minuteafter.com


### PR DESCRIPTION
Hello Maintainers,

I have found and verified many domains that are being used by disposable emails, burner inboxes, spam-traps, and typo-squatters to avoid registrations.

All these domains have been deliberately chosen and verified through publicly available temp mail database, disposable email generators, spam trap links, and typical typo domains. They give an instant inbox using mirror websites such as Mailinator, GuerrillaMail, 10MinuteMail, YOPMail, MailDrop, 1SecMail, Temp-Mail, Mohmal, etc.

Because of the large quantity, I cannot provide you with screenshots for all the domains, but I am willing to do that from the most prominent providers.