### PR TITLE
Add dollicons.com to list

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1238,6 +1238,7 @@ dodsi.com
 dogclothing.org
 doiea.com
 doj.one
+dollicons.com
 dolofan.com
 dolphinnet.net
 domforfb1.tk


### PR DESCRIPTION
https://dollicons.com/

<img width="1775" height="275" alt="image" src="https://github.com/user-attachments/assets/c554b208-7fc5-4c60-9f87-0af9dc176842" />

Bunch of fake accounts created on our platform using this domain.