### PR TITLE
Add marineso.com to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -5465,3 +5465,4 @@ zyns.com
 zzi.us
 zzrgg.com
 zzz.com
+marineso.com


### PR DESCRIPTION
To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.

https://temp-mail.org/
<img width="731" height="434" alt="temp-mail screenshot" src="https://github.com/user-attachments/assets/1fe66563-efe1-4a5c-b23b-41bf269bca44" />

