### PR TITLE
Add ameady.com to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -416,6 +416,7 @@ amazon-aws.org
 amberwe.us
 ambiancewe.us
 ambitiouswe.us
+ameady.com
 amelabs.com
 americanawe.us
 americancivichub.com


### PR DESCRIPTION
ameady.com is a disposable temp email domain from temp-mail.org.

Verified via check-mail.org 
<img width="1455" height="920" alt="brave_screenshot_check-mail org" src="https://github.com/user-attachments/assets/d4d39c07-295f-4fba-9b76-2e2d570c3c81" />
 risk score 91/100, is_disposable: true.
Screenshot attached.

Ran maintain.sh to sort and deduplicate.
