### PR TITLE
Handle empty lines gracefully in verify.py

### DIFF
--- a/verify.py
+++ b/verify.py
@@ -68,8 +68,11 @@ def check_for_invalid_level_domains(filename, psl, psl_local):
     Public suffixes are supplied from two sources: online database and local list.
     """
     invalid = set()
-    for line in files[filename]:
+    for line_number, line in enumerate(files[filename], start=1):
         domain = line.strip()
+        if not domain:
+            print(f"Empty or whitespace-only line detected at line {line_number} in {filename!r}. Please remove it.")
+            sys.exit(1)
         parts = domain.split('.')
         public_valid = local_valid = False
         if len(psl.privateparts(domain)) == 1:


### PR DESCRIPTION
An empty line in disposable_email_blocklist.conf currently causes:

TypeError: object of type 'NoneType' has no len()

This change detects empty lines explicitly and reports the line number, making validation failures easier to diagnose.

<img width="1519" height="330" alt="image" src="https://github.com/user-attachments/assets/9f17e6e1-a069-473f-8e4c-698efd846a54" />
