### PR TITLE
Improve blocklist normalization pipeline

### DIFF
--- a/maintain.sh
+++ b/maintain.sh
@@ -5,8 +5,11 @@ export LC_ALL=C
 
 TMPFILE=$(mktemp)
 
-# Converts uppercase to lowercase, sorts, removes duplicates
-cat disposable_email_blocklist.conf | tr '[:upper:]' '[:lower:]' | sort -f | uniq -i > $TMPFILE
+#Remove empty lines,  Convert uppercase to lowercase, sorts, removes duplicates
+grep -v '^[[:space:]]*$' disposable_email_blocklist.conf \
+| tr '[:upper:]' '[:lower:]' \
+| sort -f \
+| uniq -i > $TMPFILE
 
 mv $TMPFILE disposable_email_blocklist.conf
 


### PR DESCRIPTION
This improves the blocklist normalization pipeline in 
```bash
maintain.sh 
```

## Changes

* Remove empty lines from disposable_email_blocklist.conf before processing
* Simplify the shell pipeline