### PR TITLE
Add new domains to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -5486,3 +5486,11 @@ zyns.com
 zzi.us
 zzrgg.com
 zzz.com
+whatthefish.info
+fuadd.me
+ship79.com
+gxmail.top
+cutemails.online
+cloneiostrau.org
+onlinecmail.com
+shopcobe.com


### PR DESCRIPTION
Added new disposable email domains to the blocklist.

I am not aware where one generates those emails, but they're spamming my system for a while now.

<img width="1512" height="982" alt="Screenshot 2026-05-20 at 19 05 03" src="https://github.com/user-attachments/assets/a7e2c439-fa95-4703-84d0-16d705dd9cde" />


To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
