### PR TITLE
Added 1t-mail.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -92,6 +92,7 @@
 1secmail.website
 1st-forms.com
 1sworld.com
+1t-mail.com
 1to1mail.org
 1trick.net
 1usemail.com


### PR DESCRIPTION

<img width="870" height="488" alt="image" src="https://github.com/user-attachments/assets/d118332d-1c7f-4796-979f-406a3d363ea7" />
This is a Japanese site, but at the URL
https://www.onetime-mail.com/
you can get a disposable email address using ***@1t-mail.com.

Please add it to your list.

