### PR TITLE
Add web-library.net

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -6506,6 +6506,7 @@ wearvault.biz.id
 web-contact.info
 web-ideal.fr
 web-inc.net
+web-library.net
 web-mail.pp.ua
 web2mailco.com
 webclub.infos.st


### PR DESCRIPTION
## Summary
- Add `web-library.net` to the disposable email domain blocklist.

## Validation
- Ran `./maintain.sh`.
- Ran `python verify.py` in a temporary virtualenv after installing `requirements.txt`; all domain entries are valid.

## Evidence
Cant find the place where people create this emails from, but many checkers get it as disposable

[Skipsend](https://skipsend.com/check/web-library.net/)

<img width="1023" height="995" alt="Screenshot 2026-06-12 at 19 26 34" src="https://github.com/user-attachments/assets/95062aa9-0d95-48dc-86e4-b051752a39fc" />

[UserCheck](https://www.usercheck.com/domain/web-library.net)

<img width="1299" height="1027" alt="Screenshot 2026-06-12 at 19 26 56" src="https://github.com/user-attachments/assets/590f122b-5377-4b05-9e80-9141263ace6a" />

