### PR TITLE
Add emailinbo.live

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1882,6 +1882,7 @@ emailhook.site
 emailias.com
 emailigo.de
 emailinfive.com
+emailinbo.live
 emailisvalid.com
 emailkp.com
 emaillime.com

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1881,8 +1881,8 @@ emailgo.de
 emailhook.site
 emailias.com
 emailigo.de
-emailinfive.com
 emailinbo.live
+emailinfive.com
 emailisvalid.com
 emailkp.com
 emaillime.com


### PR DESCRIPTION
`emailinbo.live` is one of the rotating domains used by [mohmal.com](https://www.mohmal.com/en), a free temporary email service that generates disposable addresses expiring after 45 minutes.