### PR TITLE
Added Tinyhost new domain fetcher

### DIFF
--- a/fetch_domains.py
+++ b/fetch_domains.py
@@ -229,6 +229,39 @@ class GPTMailFetcher(DomainFetcher):
 
         return domains
 
+    class TinyhostFetcher(DomainFetcher):
+    """Fetcher for `tinyhost shop` disposable email domains"""
+
+    def __init__(self):
+        super().__init__("Tinyhost")
+        self.url = "https://tinyhost.shop/api/all-domains/"
+
+    def fetch(self) -> Set[str]:
+        """Fetch all online domains from the Tinyhost API"""
+        try:
+            response = get(self.url, timeout=30)
+            response.raise_for_status()
+        except Exception as e:
+            print(f"Error fetching {self.name} domains: {e}", file=sys.stderr)
+            return set()
+
+        try:
+            data = response.json()
+        except Exception as e:
+            print(f"Error parsing JSON from {self.name}: {e}", file=sys.stderr)
+            return set()
+
+        domains = set()
+        if isinstance(data, dict) and "domains" in data:
+            for domain in data["domains"]:
+                domain = domain.lower().strip()
+                if domain:
+                    domains.add(domain)
+
+        if not domains:
+            print(f"Warning: No domains found from {self.name}. The page structure may have changed.", file=sys.stderr)
+        return domains
+
 
 def load_existing_domains(filename: str) -> Set[str]:
     """Load existing domains from blocklist file"""
@@ -295,6 +328,7 @@ FETCHERS = [
     NoopmailFetcher(),
     YoursToolsFetcher(),
     GPTMailFetcher(),
+    TinyhostFetcher(),
     # Example: AnotherFetcher(),
 ]
 


### PR DESCRIPTION
I looked at API docs of Tinyhost so i used https://tinyhost.shop/api/all-domains/  to get all domains when we put this link in browser it gives the list all such disposabel 827 domains 
```
{
  "domains": ["khaibn.com", "trungmetax.com", ...],
  "total": 827,
  "last_updated": "2026-06-15T07:04:10.884599"
} this is the exact output i get when i put the link in browser though. 
```
In 
```
if isinstance(data, dict) and "domains" in data:
    for domain in data["domains"]: 
        if isinstance(domain, str) and domain:
            domains.add(domain.lower().strip()
```
``` data["domains"] ``` will get this output perfectly. It will check id the response is a dict and has `"domains"` key and will loop over 827 domain strings checking if it is a non-empty string and then it will add that to domains set