### PR TITLE
Add email on deck domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -676,6 +676,7 @@ ashleyandrew.com
 asia-hq.jo3.org
 asimarif.com
 ask-mail.com
+asleepity.com
 asorent.com
 aspireviastudios.org
 ass.pp.ua
@@ -910,6 +911,7 @@ beautifulblessingsbeyondborders.org
 beddly.com
 beefmilk.com
 beelsil.com
+beganment.com
 begemail.com
 behatifoundation.org
 bekasi.me
@@ -920,6 +922,7 @@ beluckygame.com
 benipaula.org
 benphim.com
 benphim.net
+benshelf.com
 bepureme.com
 beribase.ru
 beribaza.ru
@@ -1032,6 +1035,7 @@ botasky.eu.cc
 botgetlink.com
 botgetlink.net
 botnet.my.id
+boukshilf.com
 boun.cr
 bouncr.com
 box-mail.ru
@@ -1056,6 +1060,7 @@ brand-app.biz
 brandallday.net
 brashbeat.online
 brasx.org
+breaite.com
 breakthru.com
 brefmail.com
 brennendesreich.de
@@ -1067,6 +1072,7 @@ briggsmarcus.com
 brightfuturescharity.org.uk
 bristolstatehousefoundation.org
 broadbandninja.com
+brokenion.com
 brownjasen.ccwu.cc
 bskyx.fun
 bsnow.net
@@ -1258,6 +1264,7 @@ chewydonut.com
 chibakenma.ml
 chickenkiller.com
 chielo.com
+childrenth.com
 childsavetrust.org
 chilkat.com
 chilloliandfii.space
@@ -1418,6 +1425,7 @@ cotasen.com
 cotigz.com
 courriel.fr.nf
 courrieltemporaire.com
+cousinment.com
 coza.ro
 cozilla.pw
 cpc.cx
@@ -1834,6 +1842,7 @@ dunkos.xyz
 durandinterstellar.com
 duskmail.com
 dusrui.com
+dustinry.com
 duya25446.top
 dv2.host
 dvdpit.com
@@ -2083,6 +2092,7 @@ epsteinisland.click
 epurcf.org
 eqiluxspam.ga
 equivara.cfd
+erahods.com
 ereplyzy.com
 ericjohnson.ml
 eripo.net
@@ -2094,6 +2104,7 @@ esc.la
 escapehatchapp.com
 esemay.com
 esgeneri.com
+eshimod.com
 esiix.com
 esprity.com
 estate-invest.fr
@@ -2138,6 +2149,7 @@ exclussi.com
 exdonuts.com
 exelica.com
 exespay.com
+exhaycle.com
 exile.my.id
 existiert.net
 exitbit.com
@@ -2146,11 +2158,13 @@ exkucn.ccwu.cc
 exmab.com
 expiredtoaster.org
 explodemail.com
+expltain.com
 express.net.ua
 extracurricularsociety.com
 extraku.net
 extraku.shop
 extremail.ru
+extrset.com
 exweme.com
 ey-hungry.top
 eycfhb.com
@@ -2311,6 +2325,7 @@ fixmail.tk
 fizmail.com
 fkainc.com
 flaimenet.ir
+flavourity.com
 flayeraaron.eu.cc
 flayerhu.eu.cc
 fleckens.hu
@@ -3147,6 +3162,7 @@ ikuromi.com
 illistnoise.com
 illnessth.com
 illubd.com
+iloveion.com
 ilovespam.com
 im5z.com
 imagic.wiki
@@ -3514,6 +3530,7 @@ khoke.nl
 khtextile.com
 kiani.com
 kidaroa.com
+kiecchn.com
 kiki287666.xyz
 killmail.com
 killmail.net
@@ -3703,6 +3720,7 @@ levi.cc.cd
 lez.se
 lgxscreen.com
 lhsdv.com
+liadhene.com
 liamcyrus.com
 liangganxiaopu.bond
 libinit.com
@@ -3712,6 +3730,7 @@ lifebyfood.com
 lifetimefriends.info
 lifetotech.com
 lifetreechurch.co.uk
+liggegi.com
 lightv.online
 ligsb.com
 likeageek.fr.nf
@@ -4572,6 +4591,7 @@ nashapoultryshop.com
 naslazhdai.ru
 natange.org.uk
 nationalgardeningclub.com
+natuanal.com
 nautonk.com
 navalcadets.com
 naverapp.com
@@ -4912,6 +4932,7 @@ osaxadinhos.com.br
 oshietechan.link
 osifixtech.com.mx
 oskarstalbergcitygenerator.com
+ospirun.com
 ostahie.com
 ostinmail.com
 osxofulk.com
@@ -5147,6 +5168,7 @@ pride-worldwi.de
 primabananen.net
 prin.be
 printz.site
+prisonity.com
 privacy-mail.top
 privacy.net
 privacyshield.cc
@@ -5182,6 +5204,7 @@ protectsmail.net
 protempmail.com
 protonza.com
 prout.be
+proveity.com
 proxy-gateway.net
 proxymail.eu
 proxyparking.com
@@ -5194,6 +5217,7 @@ psles.com
 psnator.com
 psoxs.com
 ptct.net
+ptncereio.com
 ptsculure.com
 puabook.com
 puglieisi.com
@@ -5232,6 +5256,7 @@ qd.je
 qd28max.eu.cc
 qejjyl.com
 qentic.shop
+qeurtor.com
 qhgs.com
 qiang66.ccwu.cc
 qibl.at
@@ -5282,6 +5307,7 @@ rabiot.reisen
 rabitex.com
 racaho.com
 rackabzar.com
+racovor.com
 rael.us
 raetp9.com
 rainbowly.ml
@@ -5415,6 +5441,7 @@ rosebearmylove.ru
 rotaniliam.com
 rotomails.co.uk
 rotomails.com
+rouflav.com
 route64.de
 routerboardvietnam.com
 rover.info
@@ -5446,6 +5473,7 @@ rustyload.com
 ruu.kr
 ruutukf.com
 rvb.ro
+rvneous.com
 rwstatus.com
 rwxsxnomo.top
 rxs9.cn
@@ -5492,6 +5520,7 @@ sanfnges.cc
 sanim.net
 sanstr.com
 saovangtiles.site
+sappisi.com
 sast.ro
 sasukiez.shop
 satisfyme.club
@@ -5617,6 +5646,7 @@ shortweb.live
 shotmail.ru
 showslow.de
 shrib.com
+shuelder.com
 shut.name
 shut.ws
 siberpay.com
@@ -5765,6 +5795,7 @@ soniot.store
 sonjj.edu.pl
 sonny.tk
 sonphuongthinh.com
+sonrusu.com
 sonshi.cf
 soodmail.com
 soodomail.com
@@ -6182,6 +6213,7 @@ thameschamberorchestra.co.uk
 thanhnhontienbao.com
 thanksnospam.info
 thankyou2010.com
+thaotri.com
 thatim.info
 thc.st
 thdfyrg.top
@@ -6224,6 +6256,7 @@ thex.ro
 thg.cc.cd
 thichanthit.com
 thichmmo.com
+thiefness.com
 thietbivanphong.asia
 thirifara.com
 thisisnotmyrealemail.com
@@ -6473,6 +6506,7 @@ tubeemail.com
 tumroc.net
 tuofs.com
 tupmail.com
+turkeyth.com
 turnimon.com
 turoid.com
 turual.com
@@ -6509,6 +6543,7 @@ ubm.md
 ucche.us
 ucupdong.ml
 uddinfoundation.org
+udingclin.com
 uemail99.com
 ufacturing.com
 ufokeuabmail.com
@@ -6539,6 +6574,7 @@ umombiss.tk
 undeadbank.com
 underseagolf.com
 undo.it
+unfairship.com
 unicodeworld.com
 unids.com
 unimark.org
@@ -6546,6 +6582,7 @@ uniromax.com
 unit7lahaina.com
 unitedcharitiesosm.org.uk
 universall.me
+unlikeyth.com
 unmail.ru
 unratito.com
 uofzcpg9ftykob.asia
@@ -6829,6 +6866,7 @@ web-inc.net
 web-library.net
 web-mail.pp.ua
 web2mailco.com
+webcamness.com
 webclub.infos.st
 webcontact-france.eu
 webemail.me
@@ -7110,6 +7148,7 @@ yilue.eu.org
 ying-ge.com
 yingzi321.shop
 yjlwcbrf.top
+ymonthl.com
 ynmrealty.com
 yodx.ro
 yogamaven.com


### PR DESCRIPTION
Fixes #568 

A user posted a list of (potential) email on deck domains here https://github.com/GeroldSetz/emailondeck.com-domains

I made a simple Python script that filters these domains and checks if they redirect to `pro.emailondeck.com`
```
HTTP/1.1 302 Found
content-type: text/plain
content-length: 0
date: Tue, 16 Jun 2026 16:25:23 GMT
x-frame-options: SAMEORIGIN
strict-transport-security: max-age=2592000
cache-control: private, no-cache, no-store, max-age=0
expires: Mon, 01 Jan 1990 0:00:00 GMT
location: http://postj29ouc.rouflav.com

HTTP/1.1 301 Moved Permanently
Date: Tue, 16 Jun 2026 16:25:24 GMT
Server: Apache
Content-Security-Policy: frame-ancestors 'self';
X-Frame-Options: SAMEORIGIN
Location: https://pro.emailondeck.com/
Content-Type: text/html; charset=iso-8859-1
```

This PR is the result of that script