### PR TITLE
Add private.icloud.com to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -5477,6 +5477,7 @@ privacy-mail.top
 privacy.net
 privacyshield.cc
 privatdemail.net
+private.icloud.com
 privmail.edu.pl
 privy-mail.com
 privy-mail.de


### PR DESCRIPTION
The domain "private.icloud.com" is a new disposable email domain announced at https://developer.apple.com/news/?id=sus6t6ab

<img width="748" height="410" alt="Screenshot 2026-06-26 at 20 30 58" src="https://github.com/user-attachments/assets/7c83651c-5ad7-4263-8369-fcb209dc4d27" />

<img width="456" height="525" alt="Screenshot 2026-06-26 at 20 29 00" src="https://github.com/user-attachments/assets/cd6a480a-c18f-41ea-ac5c-7fc99a0ba660" />

