### PR TITLE
Add 59 disposable domains from an observed trial-abuse campaign

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -113,11 +113,13 @@
 191117636.cfd
 191mariobet.com
 199411.store
+1bin.sbs
 1blackmoon.com
 1ce.us
 1chuan.com
 1clck2.com
 1fsdfdsfsdf.tk
+1mail.lt
 1mail.ml
 1nom.org
 1pad.de
@@ -243,6 +245,7 @@
 521883.xyz
 52mails.com
 55hosting.net
+57win.lat
 5ghgfhfghfgh.tk
 5gramos.com
 5july.org
@@ -296,6 +299,7 @@
 7novels.com
 7tags.com
 7xusq8vbim5d47.icu
+7ybig.lat
 80665.com
 80fight.cn
 8127ep.com
@@ -436,6 +440,7 @@ aegiswe.us
 aelo.es
 aeonpsi.com
 aerionx25k.io.vn
+aeris.lat
 aeronyx.cfd
 aesel.me
 aetheron.cfd
@@ -483,6 +488,7 @@ aidesign.work.gd
 aidesigner.2bd.net
 aifmusic.top
 aikunkun.com
+ailet.lat
 ailicke.com
 aineapi.com
 aiphotoeditor.io
@@ -575,6 +581,7 @@ altmails.com
 altrans.fr.nf
 altuswe.us
 aluimport.com
+alunm.com
 alvaxio.com
 alves.fr.nf
 alwayss.uno
@@ -693,6 +700,7 @@ arapgege.app
 arapps.me
 arcadein.com
 arcentra.cfd
+archi.lat
 ardsp.shop
 arduino.hk
 arenahiveai.com
@@ -742,6 +750,7 @@ atelierdelune.shop
 atlasimple.com
 atmemail.top
 atnextmail.com
+ato88.lat
 atombomb.online
 attnetwork.com
 au1688x.us
@@ -1006,6 +1015,7 @@ bestoption25.club
 bestparadize.com
 bestsoundeffects.com
 besttempmail.com
+bet60.lat
 beta.edu.pl
 betacinder.com
 betatensor.com
@@ -1584,6 +1594,7 @@ cubiclink.com
 cucadas.com
 cuendita.com
 cuirushi.org
+cuiwu.lat
 cumnnm.us.ci
 cuoly.com
 cuongaquarium.com
@@ -1741,6 +1752,7 @@ desmond.eu.cc
 desoz.com
 despam.it
 despammed.com
+desty.lat
 dev-null.cf
 dev-null.ga
 dev-null.gq
@@ -1963,6 +1975,7 @@ dspwebservices.com
 dtvpn.dpdns.org
 duam.net
 dubokutv.com
+ducha.lat
 duck2.club
 duckyoursick.com
 ducpham.id.vn
@@ -2010,6 +2023,7 @@ e-record.com
 e-tomarigi.com
 e3z.de
 e4ward.com
+eabet.lat
 eacademia.uk
 ealea.fr.nf
 eanok.com
@@ -2099,6 +2113,7 @@ email-fake.tk
 email-free.online
 email-jetable.fr
 email-lab.com
+email-penguin.com
 email-temp.com
 email.edu.pl
 email.net
@@ -2446,6 +2461,7 @@ fexbox.org
 fexbox.ru
 fexpost.com
 fextemp.com
+feyax.lat
 fft.edu.do
 fhoau.eu.cc
 fhpfhp.fr.nf
@@ -2819,6 +2835,7 @@ givmail.com
 gixenmixen.com
 gkd2323c.in
 gladogmi.fr.nf
+glate.org
 glaventra.cfd
 glaviu.icu
 glcspp.top
@@ -2879,12 +2896,14 @@ gonida.co.uk
 gonida.com
 gonida.uk
 googl.win
+googxs.com
 goomail.club
 goonby.com
 gooner.cat
 goplaygame.ru
 gorillaswithdirtyarmpits.com
 goround.info
+gorpa.lat
 gosarlar.com
 gosuslugi-spravka.ru
 gothere.biz
@@ -3008,6 +3027,7 @@ gptmail.webredirect.org
 gptworkone.dev
 gpxmail.win
 grabafilafoundation.org
+grabpon.com
 gracetvglobal.com
 grandmamail.com
 grandmasmail.com
@@ -3166,6 +3186,7 @@ helpjobs.ru
 helpthechildren.uk
 heocondeisng.cc
 herilev.top
+herojp.com
 heros3.com
 herp.in
 herpderp.nl
@@ -3214,6 +3235,7 @@ himail.online
 histartool.com
 hitbase.net
 hitbtcpool.cloud
+hitzcart.com
 hkvtop.us
 hldrive.com
 hlkes.com
@@ -3290,6 +3312,7 @@ hthlm.com
 http.nyc.mn
 httpsgreenwichmeantime.in
 huage.me
+huamo.lat
 huangao.xyz
 huangniu8.com
 hubglee.com
@@ -3479,6 +3502,7 @@ instaddr.win
 instance-email.com
 instant-mail.de
 instantblingmail.info
+instantbox.live
 instantemailaddress.com
 instantletter.net
 instantmail.fr
@@ -4391,6 +4415,7 @@ makemenaughty.club
 makemetheking.com
 makertrial.com
 makoli.sbs
+makoli.store
 malahov.de
 malayalamdtp.com
 malioter.pro
@@ -4500,6 +4525,7 @@ mfsa.info
 mfsa.ru
 mfunza.com
 mfxis.com
+mgbet.lat
 mgxianlu.gq
 mhzayt.online
 miaferrari.com
@@ -4880,6 +4906,7 @@ nakedtruth.biz
 namdevmail2.qzz.io
 namenan.me
 namewok.com
+nanana.uk
 naniniva.com
 nanonym.ch
 nanopools.info
@@ -4943,6 +4970,7 @@ netricity.nl
 netris.net
 netviewer-france.com
 netzidiot.de
+neuro.lat
 nevermail.de
 neverover.life
 new-api.cc.cd
@@ -5340,6 +5368,7 @@ patonce.com
 pavilionx2.com
 pawobby.cfd
 paxlys.com
+payad.lat
 paylaar.com
 payperex2.com
 payspun.com
@@ -5389,6 +5418,7 @@ physicaladithama.io
 pi.vu
 piaa.me
 picdirect.net
+pickmemail.com
 pickuplanet.com
 picturehostel.com
 picturehostel.fr
@@ -5689,6 +5719,7 @@ randomail.net
 rapidefr.fr.nf
 rapt.be
 raqid.com
+ratas.lat
 ravavo.bond
 raveqxon.blog
 rawr.foo
@@ -5864,6 +5895,7 @@ s1q59z82q.top
 s33db0x.com
 s3k.net
 s4sfoundation.org.uk
+sabor.lat
 sabrestlouis.com
 sackboii.com
 sad23321adja.cn
@@ -5910,6 +5942,7 @@ satukosong.com
 saturrshop.uk
 saungadaid.pro
 sausen.com
+savdz.com
 save4now.com
 savemydinar.com
 savests.com
@@ -5951,6 +5984,7 @@ seedspeed.site
 seekapps.com
 seekjobs4u.com
 sehier.fr
+sehod.lat
 sejaa.lv
 sekotong.store
 selaciptama.com
@@ -6037,6 +6071,7 @@ shopbantkclone.com
 shopcreative.cc
 shopempva11.com
 shopld.linkpc.net
+shopsprint.org
 shopvipduzk666.shop
 shopvipduzk6868.shop
 shopxda.com
@@ -6045,6 +6080,7 @@ shortmail.net
 shortweb.live
 shotmail.ru
 showslow.de
+shred.lat
 shrib.com
 shuelder.com
 shut.name
@@ -6073,11 +6109,13 @@ silvaron.cfd
 silvercoin.life
 sim-simka.ru
 simaenaga.com
+siman.lat
 simoka.sbs
 simpleitsecurity.info
 simranaitech.space
 sin.cl
 sinaite.net
+sinbox.asia
 sind-hier.com
 sind-wir.com
 sindhier.com
@@ -6098,6 +6136,7 @@ sizzlemctwizzle.com
 sjuaq.com
 sjusngde.info
 sk-ai.eu.cc
+skatingion.com
 skeefmail.com
 skingkong.com
 skrak.com
@@ -6308,6 +6347,7 @@ sparkletoc.com
 speak2all.com
 speaknow.org.uk
 specialneedscircle.co.uk
+speeddataanalytics.com
 speedgaus.net
 speedlooking.fun
 sperma.cf
@@ -6693,6 +6733,7 @@ thetechnext.net
 theweifamily.icu
 thex.ro
 thg.cc.cd
+thhdfws.us
 thichanthit.com
 thichmmo.com
 thiefness.com
@@ -7031,10 +7072,12 @@ unfairship.com
 unicodeworld.com
 unids.com
 unimark.org
+unioc.asia
 uniromax.com
 unit7lahaina.com
 unitedcharitiesosm.org.uk
 universall.me
+universitas.codes
 unlikeyth.com
 unmail.ru
 unratito.com
@@ -7042,12 +7085,14 @@ uofzcpg9ftykob.asia
 uooos.com
 uorak.com
 upc.infos.st
+upipaid.com
 upliftnow.com
 uplipht.com
 uploadnolimit.com
 upozowac.info
 upphim.net
 upsnab.net
+uptra.lat
 uqqlrdi.top
 urfunktion.se
 urgentmail.ovh
@@ -7070,6 +7115,7 @@ ushijima1129.gq
 ushijima1129.ml
 ushijima1129.tk
 usm.ovh
+usmail.one
 ustorp.com
 usus.accesscam.org
 usus.camdvr.org
@@ -7112,6 +7158,7 @@ vdig.com
 veanlo.com
 veb37.com
 vectorbrasil.app
+vektoru.com
 velatrix.cfd
 veletis.bond
 velmoor.org
@@ -7196,6 +7243,7 @@ vipepe.com
 vipmail.name
 vipmail.pw
 vipmba.cc
+vipph.lat
 vips.pics
 vipxm.net
 viralplays.com
@@ -7318,6 +7366,7 @@ waroengin.com
 waroengkuy.com
 waroengmail.com
 waroengpremium.com
+waroengpt.com
 warrity25k.io.vn
 warunkto.com
 watch-harry-potter.com
@@ -7342,6 +7391,7 @@ web-inc.net
 web-library.net
 web-mail.pp.ua
 web2mailco.com
+web5h.com
 webcamness.com
 webclub.infos.st
 webcontact-france.eu
@@ -7396,6 +7446,7 @@ wemel.top
 wenkuu.com
 wentcity.com
 wep.email
+westecom.com
 wetrainbayarea.com
 wetrainbayarea.org
 weyword.cfd
@@ -7548,6 +7599,7 @@ xiaoting.cc
 xib.icu
 xidealx.com
 xikemail.com
+ximbo.lat
 ximenor.site
 xingmeisofa.com
 xirentha.cfd
@@ -7615,6 +7667,7 @@ yannmail.win
 yanxuan.eu.cc
 yapped.net
 yaqp.com
+yarda.lat
 yarnpedia.ga
 ybidbccmv.top
 yc08.cn
@@ -7639,6 +7692,7 @@ yihacihuy.top
 yilue.eu.org
 ying-ge.com
 yingzi321.shop
+yiole.lat
 yjlwcbrf.top
 ymonthl.com
 ynagjie-66.cc
@@ -7770,6 +7824,7 @@ zepp.dk
 zeronerbacomail.com
 zeropolly.com
 zetmail.com
+zetva.org
 zevionyx.com
 zfymail.com
 zhaji.eu.org
@@ -7784,6 +7839,7 @@ zhjjq.tech
 zhorachu.com
 zhousj.eu.org
 zik.dj
+zikozikoqq.shop
 zipcad.com
 zipcatfish.com
 ziping.me
@@ -7814,8 +7870,10 @@ zovion.com
 zozozo123.com
 zsero.com
 zsmj.cc.cd
+zsoc.site
 zsts.top
 zudpck.com
+zuigaodeshanfeng.icu
 zuldev.live
 zumnime.me
 zumpul.com
@@ -7835,6 +7893,7 @@ zyranova.cfd
 zyvenix.cfd
 zzi.us
 zzrgg.com
+zzwin.lat
 zzz.com
 zzzzzzzzzzzzzz-1090.dynv6.net
 zzzzzzzzzzzzzz-2092.dynv6.net


### PR DESCRIPTION
These 59 domains were used by a coordinated free-trial-farming operation observed on a production SaaS between May and July 2026: freshly-registered throwaway domains (many with self-hosted MX so they pass basic MX validation) plus a handful of public temp-mail services, used to mint hundreds of trial accounts for automated scraping.

The bulk are `*.lat` throwaways registered in batches; the rest are assorted disposable/temp-mail hosts (`instantbox.live`, `usmail.one`, `pickmemail.com`, `sinbox.asia`, etc.).

- Ran `python verify.py` — passes clean (valid levels, sorted, no duplicates).
- `*.shopsprint.org` subdomains were trimmed to the apex per verify.py's level check.