### PR TITLE
Add disposable domains: 10minute.email, 10minmail.org

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -52,8 +52,10 @@
 10mail.xyz
 10minemail.com
 10minmail.de
+10minmail.org
 10minut.com.pl
 10minut.xyz
+10minute.email
 10minutemail.be
 10minutemail.cf
 10minutemail.co.uk


### PR DESCRIPTION
Both belong to the "10 Minute Mail" disposable/temporary email service and are currently missing from the blocklist:

- 10minute.email — disposable temp-mail provider (page title "10 Minute Mail
  - Disposable Temporary Email Address for Privacy"); redirects to 10minmail.org.
- 10minmail.org — the redirect target / active service domain of the same provider. The list already had 10minmail.de but not the .org.

Verified live 2026-07-07. Inserted in sorted order (maintain.sh is a no-op).

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
