### PR TITLE
fix(blocklist): add Saply-observed domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -919,6 +919,7 @@ back67283.eu.cc
 back7654.eu.cc
 backilnge.com
 bacteroidmail.com
+badgerhole.com
 badgerland.eu
 badoop.com
 badopsec.lol
@@ -4034,6 +4035,7 @@ liangganxiaopu.bond
 libinit.com
 licccons.icu
 licenses.sbs
+lidugw.com
 lifebyfood.com
 lifetimefriends.info
 lifetotech.com
@@ -5197,6 +5199,7 @@ oborudovanieizturcii.ru
 obxpestcontrol.com
 oceva.site
 octovie.com
+ocuser.com
 odaymail.com
 odeask.com
 odem.com


### PR DESCRIPTION
## Summary
- Add three disposable-email domains observed in verified production signups.
- Cover domains that are still missing from the current upstream blocklist.
- Improve detection for consumers that refresh from this repository, including Saply.

## Changes
- Add `ocuser.com`, `badgerhole.com`, and `lidugw.com` in sorted order.
- Each domain is independently identified as a Temp-Mail domain: [ocuser.com](https://check-mail.org/domain/ocuser.com/), [badgerhole.com](https://check-mail.org/domain/badgerhole.com/), and [lidugw.com](https://check-mail.org/domain/lidugw.com/).
- All three currently resolve to the same disposable-mail infrastructure:

  ```text
  ocuser.com      -> mail.wabblywabble.com, mail.wallywatts.com
  badgerhole.com  -> mail.wabblywabble.com, mail.wallywatts.com
  lidugw.com      -> mail.wabblywabble.com, mail.wallywatts.com
  ```

- `badgerhole.com` overlaps with #970, but remains absent from `main` and that broader PR is currently conflicted.

## Testing
- `./maintain.sh`
- `.venv/bin/python verify.py`
- `git diff --check`
- Live MX lookup for all three domains

## Risk & Rollout
- This is a list-only change; consumers pick it up on their normal refresh cadence.
- False-positive risk is limited by production observations, domain-specific verification pages, and shared Temp-Mail MX infrastructure.
- Roll back by removing the affected entries.

## Checklist
- [ ] Scope and title match changes
- [ ] Tests added/updated where needed
- [ ] Docs updated where needed
