### PR TITLE
docs: add Rust implementation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,3 +391,25 @@ end
 ```
 
 Alternatively check out Elixir package https://github.com/oshanz/disposable-email.
+
+### Rust
+
+Install:
+
+```bash
+cargo add dispocheck
+```
+
+```rust
+use dispocheck::{is_disposable_domain, is_disposable_email};
+
+assert!(is_disposable_email("someone@mailinator.com"));
+assert!(is_disposable_domain("mailinator.com"));
+assert!(!is_disposable_email("someone@gmail.com"));
+```
+
+Crate:
+- https://crates.io/crates/dispocheck
+
+Repository:
+- https://github.com/ritikmitra/dispocheck-rs


### PR DESCRIPTION
## Summary

This PR adds a Rust implementation example to the README.

The project already showcases implementations for multiple ecosystems, but there wasn't a Rust example. This change adds a simple usage example and links to the published Rust crate.

Rust crate:
https://crates.io/crates/dispocheck

Repository:
https://github.com/ritikmitra/dispocheck-rs

The crate is built on top of this project's CC0 dataset and provides:

* Fast compile-time lookups
* Parent-domain matching consistent with the documented algorithm
* `no_std` support
* Automated synchronization with upstream dataset updates
* CI, tests, and documentation

Thanks for maintaining this dataset and making it available to the community!