### PR TITLE
Add secria.me to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -6178,6 +6178,7 @@ search4gpt.com
 seasonofgrace.org
 sebbcn.net
 secmail.pw
+secria.me
 secretemail.de
 secure-mail.biz
 secure-mail.cc


### PR DESCRIPTION
https://secria.me/mail/

<img width="320" height="702" alt="image" src="https://github.com/user-attachments/assets/32b98d73-2373-40cd-ad57-cc08d4602d6c" />

They run free email aliases and VPN which I'm seeing an increasing amount of spam signups across multiple products. 