### PR TITLE
Add nomomail.com to the blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -5251,6 +5251,7 @@ nomail.ga
 nomail.pw
 nomail2me.com
 nomes.fr.nf
+nomomail.com
 nomorespamemails.com
 nomorix.cfd
 nonchalantresmita.biz


### PR DESCRIPTION
Disposable email addresses using this domain can be generated at https://nomomail.com:
<img width="1385" height="1052" alt="image" src="https://github.com/user-attachments/assets/eb0fd6c3-e992-4c30-9e04-6998116ae78f" />
