### PR TITLE
Add missing domains from boomlify.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -4042,6 +4042,8 @@ kulmeo.com
 kulturbetrieb.info
 kumli.racing
 kurin.sbs
+kuromee.com
+kuromee.store
 kurumibnb.dog
 kurzepost.de
 kutakbisajauhjauh.gq
@@ -5761,6 +5763,7 @@ privy-mail.com
 privy-mail.de
 privymail.de
 priyo-mail.com
+priyo.edu.pl
 priyo.ovh
 priyo.site
 priyoemail.site


### PR DESCRIPTION
<img width="1572" height="994" alt="image" src="https://github.com/user-attachments/assets/0223c096-ef0a-4d8e-92d8-38dd1da14fc0" />

Those temp-email addresses have been used to register in some of the services that I host at https://nadeko.net just to abuse them.

Thanks for the list ^^