### PR TITLE
Add new disposable email domains to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1095,6 +1095,7 @@ bespokehaircare.co.uk
 best-hosting.biz
 best-john-boats.com
 best-temp-mail.com
+best-temp-mail.info
 best-vpn.xyz
 bestchoiceusedcar.com
 bestlistbase.com
@@ -8160,6 +8161,7 @@ youmail.ga
 youmailr.com
 youneedmore.info
 youpymail.com
+your-temp-mail.info
 your5.ru
 your5.store
 yourdomain.com


### PR DESCRIPTION
Added 'best-temp-mail.info' and 'your-temp-mail.info' to the blocklist.

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
