### PR TITLE
Add current active temp-mail.org domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1811,6 +1811,7 @@ dbunker.com
 dcctb.com
 dcemail.com
 dcpa.net
+dd2car.com
 ddat0511.click
 ddcrew.com
 ddfd.fashion
@@ -2554,6 +2555,7 @@ fantastu.com
 fantasy139.icu
 fantasymail.de
 fanymail.com
+fanzher.com
 farah.rip
 farouter.tech
 farrse.co.uk
@@ -4692,6 +4694,7 @@ manifestgenerator.com
 mannawo.com
 mansiondev.com
 maohe.cloud
+mapsguy.com
 marchguidesassociation.org
 marchguidesassociation.org.uk
 marhumal.tech
@@ -4745,6 +4748,7 @@ medevsa.com
 mediaeast.uk
 mediaholy.com
 medicichoir.org
+mediseat.com
 medkabinet-uzi.ru
 meef.uk
 meepsheep.eu
@@ -5236,6 +5240,7 @@ nekosan.uk
 neomailbox.com
 neosstudy.work
 neotlozhniy-zaim.ru
+neowd.com
 nepwk.com
 neroki.shop
 nervmich.net
@@ -5909,6 +5914,7 @@ promailt.com
 promyvia.cfd
 proprietativalcea.ro
 propscore.com
+prorises.com
 prosocial.io.vn
 protectsmail.net
 protempmail.com
@@ -6172,6 +6178,7 @@ robertspcrepair.com
 roborena.com
 robot-mail.com
 robothandcook.cfd
+robustq.com
 rodhazlitt.com
 roguemaster.dev
 rollindo.agency
@@ -6529,6 +6536,7 @@ slippery.email
 slipry.net
 sliverkeigo.fun
 slopsbox.com
+slotbeer.com
 slothmail.net
 slowpokerfrance.eu
 slowpokerfrance.fr


### PR DESCRIPTION
## Summary

Adds 8 domains currently used by **temp-mail.org** for their disposable/temporary email service:

`dd2car.com`, `fanzher.com`, `mapsguy.com`, `mediseat.com`, `neowd.com`, `prorises.com`, `robustq.com`, `slotbeer.com`

None of these were present in the blocklist (checked against main).

## Evidence

- Domains were obtained from temp-mail.org's own mailbox API: `POST https://web2.temp-mail.org/mailbox` returns generated addresses on these domains, e.g. `vagal50271@dd2car.com`, `dover70586@slotbeer.com`, `wicabe2077@fanzher.com`, `capiw15607@mediseat.com`.
- All 8 domains are currently live and accept email — each resolves MX records (`mail.<domain>`).
- Verified with the repo's own `python verify.py --fix` (exits clean, 8376 valid entries).

Screenshot (address generated on temp-mail.org using `fanzher.com`):

<img width="852" height="439" alt="Screenshot 2026-08-28 200216" src="https://github.com/user-attachments/assets/7f91e1d2-1158-4455-9fce-521eaab710f9" />

## Note for reviewers

`neowd.com` is the domain generated by temp-mail.org's API and verified active (MX: `mail.neowd.com`). An earlier revision of this description accidentally read `eowd.com` due to a formatting artifact — there is no `eowd.com` entry in this PR and no separate `eowd.com` evidence.
