### PR TITLE
Add current active temp-mail.org domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1862,6 +1862,7 @@ dbunker.com
 dcctb.com
 dcemail.com
 dcpa.net
+dd2car.com
 ddat0511.click
 ddcrew.com
 ddfd.fashion
@@ -2643,6 +2644,7 @@ fantastu.com
 fantasy139.icu
 fantasymail.de
 fanymail.com
+fanzher.com
 farah.rip
 farouter.tech
 farrse.co.uk
@@ -4875,6 +4877,7 @@ manifestgenerator.com
 mannawo.com
 mansiondev.com
 maohe.cloud
+mapsguy.com
 marchguidesassociation.org
 marchguidesassociation.org.uk
 marhumal.tech
@@ -4930,6 +4933,7 @@ medevsa.com
 mediaeast.uk
 mediaholy.com
 medicichoir.org
+mediseat.com
 medkabinet-uzi.ru
 meef.uk
 meepsheep.eu
@@ -5432,6 +5436,7 @@ nekosan.uk
 neomailbox.com
 neosstudy.work
 neotlozhniy-zaim.ru
+neowd.com
 nepwk.com
 neroki.shop
 nervmich.net
@@ -6129,6 +6134,7 @@ promailt.com
 promyvia.cfd
 proprietativalcea.ro
 propscore.com
+prorises.com
 prosocial.io.vn
 protectsmail.net
 protempmail.com
@@ -6413,6 +6419,7 @@ robertspcrepair.com
 roborena.com
 robot-mail.com
 robothandcook.cfd
+robustq.com
 rodhazlitt.com
 roguemaster.dev
 rollindo.agency
@@ -6780,6 +6787,7 @@ slippery.email
 slipry.net
 sliverkeigo.fun
 slopsbox.com
+slotbeer.com
 slothmail.net
 slowpokerfrance.eu
 slowpokerfrance.fr


### PR DESCRIPTION
## Summary

Adds 8 domains currently used by **temp-mail.org** for their disposable/temporary email service:

`dd2car.com`, `fanzher.com`, `mapsguy.com`, `mediseat.com`, `neowd.com`, `prorises.com`, `robustq.com`, `slotbeer.com`

None of these were present in the blocklist (checked against main).

> **Note:** This PR supersedes the previously closed PR #1139 (auto-closed after the contributor accidentally deleted their fork). Same content, same evidence.

## Evidence

- Domains were obtained from temp-mail.org's own mailbox API: `POST https://web2.temp-mail.org/mailbox` returns generated addresses on these domains, e.g. `vagal50271@dd2car.com`, `dover70586@slotbeer.com`, `wicabe2077@fanzher.com`, `capiw15607@mediseat.com`.
- All 8 domains are currently live and accept email — each resolves MX records (`mail.<domain>`).
- Confirmed via repeated sampling over multiple days/IPs (~70+ mailbox generations across 4 days, no additional domains in the pool).
- Verified with the repo's own `python verify.py --fix` (exits clean, 8703 valid entries).

Screenshot (address generated on temp-mail.org using `fanzher.com`):

<img width="852" height="439" alt="Screenshot 2026-08-28 200216" src="https://github.com/user-attachments/assets/7f91e1d2-1158-4455-9fce-521eaab710f9" />
