### PR TITLE
Add TempMailFetcher for automated temp-mail.org pool discovery

### DIFF
--- a/fetch_domains.py
+++ b/fetch_domains.py
@@ -366,6 +366,9 @@ class TempMailFetcher(DomainFetcher):
             for _ in range(30):
                 try:
                     response = post(self.url, json=payload, headers=headers, timeout=15)
+                    # Stop early on hard blocks (Cloudflare 403, auth 401)
+                    if response.status_code in (401, 403):
+                        break
                     # Stop on rate limit: {"errorMessage":"Too Many Request","errorName":"TooManyRequestsException"}
                     if response.status_code == 429 or "TooManyRequests" in response.text:
                         break
@@ -376,16 +379,22 @@ class TempMailFetcher(DomainFetcher):
                         domain = mailbox.rsplit("@", 1)[1].lower().strip()
                         if domain:
                             domains.add(domain)
-                    # Be polite to the endpoint
-                    time.sleep(2)
                 except Exception:
                     # Continue on individual request failures
-                    continue
+                    pass
+                finally:
+                    # Always wait between attempts, also after failures
+                    time.sleep(2)
         except Exception as e:
             print(f"Error fetching {self.name} domains: {e}", file=sys.stderr)
 
         if not domains:
-            print(f"Warning: No domains found from {self.name}. The page structure may have changed.", file=sys.stderr)
+            print(
+                f"Warning: No domains found from {self.name}. "
+                "This may be caused by rate limiting or IP/Cloudflare blocking, "
+                "or the endpoint may have changed.",
+                file=sys.stderr,
+            )
 
         return domains
 

--- a/fetch_domains.py
+++ b/fetch_domains.py
@@ -330,6 +330,66 @@ class CyberTempFetcher(DomainFetcher):
         return domains
 
 
+class TempMailFetcher(DomainFetcher):
+    """Fetcher for 'temp-mail org' disposable email domains.
+
+    temp-mail.org does not expose its domain list publicly (the /domains
+    endpoint requires an auth secret). The active pool is only observable
+    by requesting new mailboxes via its mailbox API, which returns a
+    randomly picked domain per call. Domains rotate over time, so sampling
+    a few times per run is enough to gradually cover the pool.
+
+    Rate limits (~5-10 mailbox creations per IP, then a short block) are
+    handled by stopping early and returning the domains collected so far.
+    """
+
+    def __init__(self):
+        super().__init__("TempMail")
+        self.url = "https://web2.temp-mail.org/mailbox"
+
+    def fetch(self) -> Set[str]:
+        """Fetch domains from temp-mail.org by polling its mailbox endpoint"""
+        import time
+        domains = set()
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+            ),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Origin": "https://temp-mail.org",
+            "Referer": "https://temp-mail.org/",
+        }
+        payload = {"method": "getMailBox", "params": {"lang": "en"}, "id": 1}
+        try:
+            for _ in range(30):
+                try:
+                    response = post(self.url, json=payload, headers=headers, timeout=15)
+                    # Stop on rate limit: {"errorMessage":"Too Many Request","errorName":"TooManyRequestsException"}
+                    if response.status_code == 429 or "TooManyRequests" in response.text:
+                        break
+                    response.raise_for_status()
+                    data = response.json()
+                    mailbox = data.get("mailbox", "")
+                    if isinstance(mailbox, str) and "@" in mailbox:
+                        domain = mailbox.rsplit("@", 1)[1].lower().strip()
+                        if domain:
+                            domains.add(domain)
+                    # Be polite to the endpoint
+                    time.sleep(2)
+                except Exception:
+                    # Continue on individual request failures
+                    continue
+        except Exception as e:
+            print(f"Error fetching {self.name} domains: {e}", file=sys.stderr)
+
+        if not domains:
+            print(f"Warning: No domains found from {self.name}. The page structure may have changed.", file=sys.stderr)
+
+        return domains
+
+
 def load_existing_domains(filename: str) -> Set[str]:
     """Load existing domains from blocklist file"""
     try:
@@ -397,6 +457,7 @@ FETCHERS = [
     OpenInboxFetcher(),
     GeneratorEmailFetcher(),
     CyberTempFetcher(),
+    TempMailFetcher(),
     # Example: AnotherFetcher(),
 ]
 


### PR DESCRIPTION
## Summary

Adds a `TempMailFetcher` to `fetch_domains.py`, so the daily "Fetch new domains" bot can automatically discover temp-mail.org's active (rotating) domain pool.

## Why a new fetcher

temp-mail.org does **not** expose its domain list publicly — the `/domains` endpoint requires an auth secret, and the page loads the pool via obfuscated JS. The only reliable observation method is the legacy mailbox API:

```
POST https://web2.temp-mail.org/mailbox
{"method":"getMailBox","params":{"lang":"en"},"id":1}
→ {"token":"eyJ...","mailbox":"vamesix677@prorises.com"}
```

Each call returns a randomly picked domain from the active pool — the same sampling approach already used by `NoopmailFetcher` (which polls `/api/rd` for random domains).

## Design

- Samples up to 30 mailbox generations, 2s apart
- Stops cleanly on the per-IP rate limit (`TooManyRequestsException`, ~5–10 calls/IP) and returns whatever was collected
- Because the daily run only adds *missing* domains, partial coverage per run is fine — the rest of the pool is picked up by subsequent runs
- Degrades gracefully on blocking (Cloudflare/403): empty set → warning, no crash, other fetchers unaffected

## Verification

- Code compiles and registers correctly in `FETCHERS`
- Standalone identical-logic run collected 6 unique domains in one pass (e.g. `vamesix677@prorises.com`, `yetop17512@robustq.com`, `jajec44474@dd2car.com`, `xikekey145@mapsguy.com`, `womak57769@mediseat.com`, `wojegin146@fanzher.com`)
- See also: PR #1142 (adds the current pool manually; this fetcher makes such submissions automatic in the future)

## Known limitation

Like `NoopmailFetcher` (whose comment notes "Blocks github IP range - run locally via vpn/proxy"), GitHub Actions runners may be geo/IP-blocked by temp-mail.org's Cloudflare setup. If the daily run finds nothing, running locally once per week via VPN/Proxy backfills the pool — after which each new rotation is picked up within a run or two.
