### PR TITLE
Update disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -4212,6 +4212,7 @@ kerotu.com
 ket-qua.org
 ketua.id
 khaibn.com
+khanggay.eu.org
 khamu.me
 khoke.nl
 khtextile.com


### PR DESCRIPTION
Domain used by bad actor to generate random domain and to run Economic Denial of Sustainability type of attack