### PR TITLE
Add fidhost.com

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -2737,6 +2737,7 @@ fiallaspares.com
 fibmail.com
 ficken.de
 fictionsite.com
+fidhost.com
 fightallspam.com
 fighthunger.co.uk
 fightingzebras.org


### PR DESCRIPTION
Adds fidhost.com, observed being used to bypass disposable-email checks at registration.

Screenshot showing it as a working disposable inbox generator to follow (via https://temp-mail.org/en/).