### PR TITLE
Add jbsze.net and kjkpc.net (10minutemail.com feeder domains)

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -4014,6 +4014,7 @@ javindra.cfd
 jazzvip.site
 jbsze.com
 jbsze.ne
+jbsze.net
 jc58t04.kozow.com
 jcnorris.com
 jdmadventures.com
@@ -4246,6 +4247,7 @@ kisstwink.com
 kitap.az
 kitnastar.com
 kiwkiw.shop
+kjkpc.net
 kjkszpjcompany.com
 kk.io.vn
 kkdty.dynv6.net


### PR DESCRIPTION
Both domains permanently redirect (HTTP 301) to https://10minutemail.com/, which is already in this list:

```
$ curl -sD - -o /dev/null http://jbsze.net
HTTP/1.1 301 Moved Permanently
Location: https://10minutemail.com/

$ curl -sD - -o /dev/null http://kjkpc.net
HTTP/1.1 301 Moved Permanently
Location: https://10minutemail.com/
```

`jbsze.net` is a sibling of `jbsze.com` and `jbsze.ne`, both already listed here — same base name, another TLD in the same feeder-domain family for the same service.

I wasn't able to get a screenshot of the generator actually issuing an address `@jbsze.net` specifically: the 10minutemail.com front end assigns a domain at random from its pool on each visit rather than letting you pick one, so landing on this exact TLD by chance isn't reliably reproducible. The redirect is stable and deterministic, which is why I'm submitting the header capture instead of a generator screenshot.

Real-world abuse: both domains were used within the last few days to register throwaway accounts on our production service (a transcription SaaS), each account claiming a free-tier allowance before being abandoned.

Ran `verify.py --fix` locally — no other issues, diff is the two added lines.