### PR TITLE
Add 94an.com to disposable email blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -8735,3 +8735,4 @@ zzzzzzzzzzzzzz-8874.dynv6.net
 zzzzzzzzzzzzzz-969.dynv6.net
 zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.loseyourip.com
 zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.ooguy.com
+94an.com


### PR DESCRIPTION
This change adds the domain 94an.com to the disposable email blocklist to prevent temporary addresses from this provider from being accepted.The domain was found active on the temp-mail service, as shown below:

<img width="1440" height="820" alt="94an com_temp-mail" src="https://github.com/user-attachments/assets/bbaf748c-0198-4064-9fa3-fe6a4189d255" />
