### PR TITLE
Update disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -8738,3 +8738,4 @@ zzzzzzzzzzzzzz-8874.dynv6.net
 zzzzzzzzzzzzzz-969.dynv6.net
 zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.loseyourip.com
 zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.ooguy.com
+uberip.com


### PR DESCRIPTION
uberip.com domain added.

To add domains please explain where one can generate a disposable email address which uses them, e.g. in the form of screenshots. Without this information your PR will be closed.
