### PR TITLE
Add TempMailIOFetcher for temp-mail.io domain pool

### DIFF
--- a/fetch_domains.py
+++ b/fetch_domains.py
@@ -469,6 +469,49 @@ class TempMailFetcher(DomainFetcher):
         return domains
 
 
+class TempMailIOFetcher(DomainFetcher):
+    """Fetcher for 'temp-mail io' disposable email domains.
+
+    temp-mail.io (a separate service from temp-mail.org) exposes its
+    active domain pool through a public JSON endpoint, so the domains can
+    be fetched directly.
+    """
+
+    def __init__(self):
+        super().__init__("TempMail.io")
+        self.url = "https://api.internal.temp-mail.io/api/v2/domains"
+
+    def fetch(self) -> Set[str]:
+        """Fetch domains from the temp-mail.io public domains API"""
+        try:
+            response = get(self.url, timeout=30)
+            response.raise_for_status()
+        except Exception as e:
+            print(f"Error fetching {self.name} domains: {e}", file=sys.stderr)
+            return set()
+
+        try:
+            data = response.json()
+        except Exception as e:
+            print(f"Error parsing JSON from {self.name}: {e}", file=sys.stderr)
+            return set()
+
+        domains = set()
+        if isinstance(data, dict) and isinstance(data.get("domains"), list):
+            for entry in data["domains"]:
+                if isinstance(entry, str) and entry:
+                    domains.add(entry.lower().strip())
+        elif isinstance(data, list):
+            for entry in data:
+                if isinstance(entry, str) and entry:
+                    domains.add(entry.lower().strip())
+
+        if not domains:
+            print(f"Warning: No domains found from {self.name}. The page structure may have changed.", file=sys.stderr)
+
+        return domains
+
+
 def load_existing_domains(filename: str) -> Set[str]:
     """Load existing domains from blocklist file"""
     try:
@@ -538,6 +581,7 @@ FETCHERS = [
     GeneratorEmailFetcher(),
     CyberTempFetcher(),
     TempMailFetcher(),
+    TempMailIOFetcher(),
     # Example: AnotherFetcher(),
 ]
 

--- a/fetch_domains.py
+++ b/fetch_domains.py
@@ -470,7 +470,7 @@ class TempMailFetcher(DomainFetcher):
 
 
 class TempMailIOFetcher(DomainFetcher):
-    """Fetcher for 'temp-mail io' disposable email domains.
+    """Fetcher for 'temp-mail.io' disposable email domains.
 
     temp-mail.io (a separate service from temp-mail.org) exposes its
     active domain pool through a public JSON endpoint, so the domains can


### PR DESCRIPTION
## Summary

Adds a `TempMailIOFetcher` to `fetch_domains.py`, so the daily bot keeps **temp-mail.io**'s rotating domain pool covered automatically.

## About temp-mail.io

A separate disposable-email service from temp-mail.org (different product, different pool). Unlike temp-mail.org, it **exposes its active domain list publicly**:

```
GET https://api.internal.temp-mail.io/api/v2/domains
→ {"domains":["ozsaip.com","yzcalo.com","lnovic.com","ruutukf.com","gmeenramy.com","olipii.com","ooynib.com"]}
```

## Design

- Simple GET + JSON parse (`{"domains": [...]}` list), lowercase/normalize, standard warning on empty results — mirrors `GPTMailFetcher`
- No auth required, no rate-limiting concerns (single request per run)

## Current coverage context

- 5 of the 7 currently-live temp-mail.io domains are already in the blocklist; the remaining 2 (`olipii.com`, `ooynib.com`) will be added automatically by the next daily run once this fetcher is registered
- More importantly, future pool rotations will be picked up without manual reports — same benefit our `TempMailFetcher` provides for temp-mail.org

Verified locally: fetches all 7 domains in ~0.4s, registers in `FETCHERS`, compiles clean.
