### PR TITLE
Add MailTmFetcher for mail.tm domain pool (#1162)

### DIFF
--- a/fetch_domains.py
+++ b/fetch_domains.py
@@ -537,6 +537,7 @@ class MailTmFetcher(DomainFetcher):
     def fetch(self) -> Set[str]:
         """Fetch active domains from the mail.tm public domains API (paginated)"""
         domains = set()
+        page_size = None
         try:
             for page in range(1, 6):
                 response = get(f"{self.url}?page={page}", timeout=30)
@@ -545,14 +546,19 @@ class MailTmFetcher(DomainFetcher):
                 member = data.get("hydra:member")
                 if not isinstance(member, list) or not member:
                     break
+                # Derive the API page size from the first page instead of assuming one
+                if page_size is None:
+                    page_size = len(member)
                 for entry in member:
                     if not isinstance(entry, dict):
                         continue
-                    domain = entry.get("domain", "")
-                    if domain and entry.get("isActive", True):
+                    if entry.get("isActive") is not True:
+                        continue
+                    domain = entry.get("domain")
+                    if isinstance(domain, str) and domain:
                         domains.add(domain.lower().strip())
-                # Stop when a page returns fewer items than the page size
-                if len(member) < 30:
+                # Stop when a page returns fewer items than the first page did
+                if len(member) < page_size:
                     break
         except Exception as e:
             print(f"Error fetching {self.name} domains: {e}", file=sys.stderr)

--- a/fetch_domains.py
+++ b/fetch_domains.py
@@ -527,6 +527,42 @@ def is_public_suffix(domain: str, psl: PublicSuffixList, psl_local: Set) -> bool
     """Check if the domain is a public suffix"""
     return (psl.publicsuffix(domain) == domain) or (domain in psl_local)
 
+class MailTmFetcher(DomainFetcher):
+    """Fetcher for 'mail.tm' disposable email domains"""
+
+    def __init__(self):
+        super().__init__("Mail.tm")
+        self.url = "https://api.mail.tm/domains"
+
+    def fetch(self) -> Set[str]:
+        """Fetch active domains from the mail.tm public domains API (paginated)"""
+        domains = set()
+        try:
+            for page in range(1, 6):
+                response = get(f"{self.url}?page={page}", timeout=30)
+                response.raise_for_status()
+                data = response.json()
+                member = data.get("hydra:member")
+                if not isinstance(member, list) or not member:
+                    break
+                for entry in member:
+                    if not isinstance(entry, dict):
+                        continue
+                    domain = entry.get("domain", "")
+                    if domain and entry.get("isActive", True):
+                        domains.add(domain.lower().strip())
+                # Stop when a page returns fewer items than the page size
+                if len(member) < 30:
+                    break
+        except Exception as e:
+            print(f"Error fetching {self.name} domains: {e}", file=sys.stderr)
+
+        if not domains:
+            print(f"Warning: No domains found from {self.name}. The page structure may have changed.", file=sys.stderr)
+
+        return domains
+
+
 # Registry of all domain fetchers
 FETCHERS = [
     YopmailFetcher(),
@@ -538,6 +574,7 @@ FETCHERS = [
     GeneratorEmailFetcher(),
     CyberTempFetcher(),
     TempMailFetcher(),
+    MailTmFetcher(),
     # Example: AnotherFetcher(),
 ]
 


### PR DESCRIPTION
## Summary

Adds a `MailTmFetcher` for **mail.tm** (per #1162), keeping its rotating domain pool covered automatically.

## Context

- mail.tm's current domain (`uberip.com`) is **already in the blocklist** — the immediate request in #1162 is covered
- However, mail.tm **rotates its domains** (e.g., `uberip.com` was created 2026-09-03 — fresh!). This fetcher ensures future pool changes are picked up daily without manual reports

## API

mail.tm exposes a **public paginated domains API**:

```
GET https://api.mail.tm/domains?page=N
→ {"hydra:member":[{"domain":"uberip.com","isActive":true,...}], "hydra:totalItems":1}
```

The fetcher:
- Pages through the results (up to 5 pages, stops on short page)
- Filters to active domains only (`isActive`)
- Normalizes to lowercase, standard warning on empty results

Verified locally: fetches the active domain(s) in ~0.4s, compiles clean, registers in `FETCHERS`.
